### PR TITLE
Change script CDN URL's to https

### DIFF
--- a/examples/graph2d/08_performance.html
+++ b/examples/graph2d/08_performance.html
@@ -15,7 +15,7 @@
     </style>
 
     <!-- note: moment.js must be loaded before vis.js, else vis.js uses its embedded version of moment.js -->
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
 
     <script src="../../dist/vis-timeline-graph2d.min.js"></script>
     <link href="../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />

--- a/examples/graph2d/13_localization.html
+++ b/examples/graph2d/13_localization.html
@@ -13,7 +13,7 @@
     }
   </style>
 
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.1/moment-with-locales.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.1/moment-with-locales.min.js"></script>
   <script src="../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
 </head>

--- a/examples/timeline/dataHandling/loadExternalData.html
+++ b/examples/timeline/dataHandling/loadExternalData.html
@@ -10,7 +10,7 @@
   </style>
 
   <!-- Load jquery for ajax support -->
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />

--- a/examples/timeline/editing/tooltipOnItemChange.html
+++ b/examples/timeline/editing/tooltipOnItemChange.html
@@ -2,7 +2,7 @@
 <head>
   <title>Timeline | Tooltip on item onUpdateTime Option</title>
 
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
 

--- a/examples/timeline/groups/groups.html
+++ b/examples/timeline/groups/groups.html
@@ -17,7 +17,7 @@
   </style>
 
   <!-- note: moment.js must be loaded before vis.js, else vis.js uses its embedded version of moment.js -->
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
 
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />

--- a/examples/timeline/groups/nestedGroups.html
+++ b/examples/timeline/groups/nestedGroups.html
@@ -17,7 +17,7 @@
   </style>
 
   <!-- note: moment.js must be loaded before vis.js, else vis.js uses its embedded version of moment.js -->
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
 
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis.min.css" rel="stylesheet" type="text/css" />

--- a/examples/timeline/other/functionLabelFormats.html
+++ b/examples/timeline/other/functionLabelFormats.html
@@ -17,7 +17,7 @@
   </style>
 
   <!-- note: moment.js must be loaded before vis.js, else vis.js uses its embedded version of moment.js -->
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
 
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />

--- a/examples/timeline/other/loadingScreen.html
+++ b/examples/timeline/other/loadingScreen.html
@@ -3,7 +3,7 @@
 
 <head>
   <title>Timeline | Loading screen example</title>
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
 </head>

--- a/examples/timeline/other/localization.html
+++ b/examples/timeline/other/localization.html
@@ -10,7 +10,7 @@
     }
   </style>
 
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.1/moment-with-locales.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.1/moment-with-locales.min.js"></script>
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
   

--- a/examples/timeline/other/onTimeout.html
+++ b/examples/timeline/other/onTimeout.html
@@ -7,7 +7,7 @@
 
 <head>
   <title>Timeline | onTimeout example</title>
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
 </head>

--- a/examples/timeline/other/performance.html
+++ b/examples/timeline/other/performance.html
@@ -11,7 +11,7 @@
   </style>
 
   <!-- note: moment.js must be loaded before vis.js, else vis.js uses its embedded version of moment.js -->
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
 
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />

--- a/examples/timeline/other/rtl.html
+++ b/examples/timeline/other/rtl.html
@@ -3,7 +3,7 @@
 <head>
   <title>Timeline | RTL example</title>
 
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
   

--- a/examples/timeline/other/stressPerformance.html
+++ b/examples/timeline/other/stressPerformance.html
@@ -7,7 +7,7 @@
 
 <head>
   <title>Timeline | Stress Performance example</title>
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
 </head>

--- a/examples/timeline/other/verticalScroll.html
+++ b/examples/timeline/other/verticalScroll.html
@@ -2,7 +2,7 @@
 <head>
   <title>Timeline | Vertical Scroll Option</title>
 
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
   <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
 

--- a/examples/timeline/styling/itemTemplates.html
+++ b/examples/timeline/styling/itemTemplates.html
@@ -4,7 +4,7 @@
   <title>Timeline | Templates</title>
 
   <!-- load handlebars for templating, and create a template -->
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.5/handlebars.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.5/handlebars.min.js"></script>
   <script id="item-template" type="text/x-handlebars-template">
     <table class="score">
       <tr>

--- a/examples/timeline/styling/weekStyling.html
+++ b/examples/timeline/styling/weekStyling.html
@@ -3,7 +3,7 @@
 <head>
     <title>Timeline | Grid styling</title>
 
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment-with-locales.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment-with-locales.min.js"></script>
     <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
     <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css"/>
 


### PR DESCRIPTION
Githup is all https causing mixed content from CDN's to fail loading with the below message. All CDN URL's used in examples should be changed to https.

Blocked loading mixed active content “http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js”