### PR TITLE
README/rollup config update for build excluding external libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Then, the project can be build running:
 
     $ npm run build
 
+### Excluding external dependencies
+
+External dependencies such as moment, hammerjs can be excluded in the build by running:
+
+    $ npm run build -- -e [comma separated module names]
+
+Example:
+
+    $ npm run build -- -e moment,hammerjs
+
 ## Test
 
 To test the library, install the project dependencies once:

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,11 +7,17 @@ import banner from 'rollup-plugin-banner';
 import genHeader from './lib/header';
 import css from 'rollup-plugin-css-porter';
 
+const GLOBALS = {
+	moment: "moment",
+	hammerjs: "hammerjs"
+};
+
 export default [{
 	input: 'index.js',
 	output: {
 		file: 'dist/vis-timeline-graph2d.esm.js',
 		format: 'esm',
+		globals: GLOBALS
 	},
 	plugins: [
 		commonjs(),
@@ -29,7 +35,8 @@ export default [{
 		file: 'dist/vis-timeline-graph2d.min.js',
 		name: 'vis',
 		exports: 'named',
-		format: 'umd'
+		format: 'umd',
+		globals: GLOBALS
 	},
 	plugins: [
 		commonjs(),


### PR DESCRIPTION
README update for info on creating custom build excluding external libraries such as moment, hammerjs. Required when including vis-timeline on projects which already contain respective dependencies.

Added global param to rollup config, to suppress warning while building.