### PR TITLE
fixed error when hiding title in graph2d-example (fixes #50)

### DIFF
--- a/examples/graph2d/16_bothAxisTitles.html
+++ b/examples/graph2d/16_bothAxisTitles.html
@@ -172,7 +172,7 @@
             title = {text: "Title (" + axis + " axis)"};
         }
         else {
-            title = undefined;
+            title = {text: undefined};
         }
 
         if(axis == 'left') {


### PR DESCRIPTION
The validator expects an object containing "dataAxis.left.title.text". Therefore title can't be undefined. 