### PR TITLE
chore(deps): switch to @egjs/hammerjs

### DIFF
--- a/lib/module/hammer.js
+++ b/lib/module/hammer.js
@@ -1,5 +1,5 @@
 import PropagatingHammer from 'propagating-hammerjs';
-import Hammer from 'hammerjs';
+import Hammer from '@egjs/hammerjs';
 
 /**
  * Setup a mock hammer.js object, for unit testing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1086,6 +1086,14 @@
         }
       }
     },
+    "@egjs/hammerjs": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.15.tgz",
+      "integrity": "sha512-BysW5KdNiJ1Qq4JRILaX/Lx2eJGyVPsFSwKA3aJbY+SKv57lS5ZFbEdlgj5shfYPLeJGEnK1WjfleDT+y4s1aQ==",
+      "requires": {
+        "@types/hammerjs": "^2.0.36"
+      }
+    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
@@ -1790,6 +1798,11 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/hammerjs": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
+      "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ=="
     },
     "@types/minimatch": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     }
   },
   "dependencies": {
+    "@egjs/hammerjs": "^2.0.15",
     "emitter-component": "^1.1.1",
-    "hammerjs": "^2.0.8",
     "keycharm": "^0.2.0",
     "moment": "^2.20.1",
     "propagating-hammerjs": "^1.4.6",


### PR DESCRIPTION
The original Hammer.js project seems unmaintained and doesn't work in node.

All 50 tests run now although 49 out of them fail.

Closes #87.