### PR TITLE
Fixed display of ranges exceeding lower and upper boundaries

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -850,12 +850,18 @@ class Group {
     const lowerBound = range.start - interval;
     const upperBound = range.end + interval;
 
-    // this function is used to do the binary search.
-    const searchFunction = value => {
+    // this function is used to do the binary search for items having start date only.
+    const startSearchFunction = value => {
       if      (value < lowerBound)  {return -1;}
       else if (value <= upperBound) {return  0;}
       else                          {return  1;}
     };
+
+    // this function is used to do the binary search for items having start and end dates (range).
+    const endSearchFunction = value => {
+      if      (value < lowerBound)  {return -1;}
+      else                          {return  0;}
+    }
 
     // first check if the items that were in view previously are still in view.
     // IMPORTANT: this handles the case for the items with startdate before the window and enddate after the window!
@@ -867,7 +873,7 @@ class Group {
     }
 
     // we do a binary search for the items that have only start values.
-    const initialPosByStart = util.binarySearchCustom(orderedItems.byStart, searchFunction, 'data','start');
+    const initialPosByStart = util.binarySearchCustom(orderedItems.byStart, startSearchFunction, 'data','start');
 
     // trace the visible items from the inital start pos both ways until an invisible item is found, we only look at the start values.
     this._traceVisible(initialPosByStart, orderedItems.byStart, visibleItems, visibleItemsLookup, item => item.data.start < lowerBound || item.data.start > upperBound);
@@ -882,10 +888,10 @@ class Group {
     }
     else {
       // we do a binary search for the items that have defined end times.
-      const initialPosByEnd = util.binarySearchCustom(orderedItems.byEnd, searchFunction, 'data','end');
+      const initialPosByEnd = util.binarySearchCustom(orderedItems.byEnd, endSearchFunction, 'data','end');
 
       // trace the visible items from the inital start pos both ways until an invisible item is found, we only look at the end values.
-      this._traceVisible(initialPosByEnd, orderedItems.byEnd, visibleItems, visibleItemsLookup, item => item.data.end < lowerBound || item.data.end > upperBound);
+      this._traceVisible(initialPosByEnd, orderedItems.byEnd, visibleItems, visibleItemsLookup, item => item.data.end < lowerBound || item.data.start > upperBound);
     }
 
     const redrawQueue = {};


### PR DESCRIPTION
[Moved PR from timeline-plus to this repository]

Range elements exceeding lower and upper boundary are not displayed. (not only when timeline is initialized, but also on zoom in/out)

I've seen some discussions about issue that could be the same than the one I fix here, except that I've not tried to go with a single loop: #157

In summary, I've found 2 issues:

    same search function is used for start and end date search when trying to find a visible element in the orderedElement. In case of range (end), we only need to search with an element having an end date greater than the lower boundary. Considering a range as not visible because its end date is greater than the upper boundary is wrong.
    when tracing visible items, we use a break condition that takes into account only the end date. It's not possible to identify invisible items only using the end date. A range is not visible only if its end date is lower than the lower boundary OR its START date is greater than the upper boundary.

Tell me if I misunderstood something or if I did something wrong. :-)
Thanks !
