### PR TITLE
Added firing dragover event

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1737,6 +1737,15 @@ timeline.off('select', onSelect);
     </tr>
 
     <tr>
+      <td>dragover</td>
+      <td>
+        Passes a properties object as returned by the method <a href="#getEventProperties"><code>Timeline.getEventProperties(event)</code></a>.
+      </td>
+      <td>Fired when dragging over a timeline element.
+      </td>
+    </tr>
+
+    <tr>
       <td>drop</td>
       <td>
         Passes a properties object as returned by the method <a href="#getEventProperties"><code>Timeline.getEventProperties(event)</code></a>.
@@ -1744,7 +1753,6 @@ timeline.off('select', onSelect);
       <td>Fired when dropping inside the Timeline.
       </td>
     </tr>
-
 
     <tr>
       <td>mouseOver</td>

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -301,6 +301,7 @@ class Core {
      */
     function handleDragOver(event) {
       if (event.preventDefault) {
+        me.emit('dragover', me.getEventProperties(event));
         event.preventDefault(); // Necessary. Allows us to drop.
       }
 


### PR DESCRIPTION
Added capability to fire an event "dragover" when dragging over a timeline element.
Can be useful to have kind of interactive dragging (eg: display information depending on the dragging location to the user).