### PR TITLE
Prevent typescript error on no implicit any in index.d.ts

### DIFF
--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -32,6 +32,9 @@ import moment from 'moment'
 export { moment }
 import Hammer from 'hammerjs'
 export { Hammer }
+
+// TODO remove @ts-ignore when keycharm creates an index.d.ts file
+// @ts-ignore
 import keycharm from 'keycharm'
 export { keycharm }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,6 +32,9 @@ import moment from 'moment'
 export { moment }
 import Hammer from 'hammerjs'
 export { Hammer }
+
+// TODO remove @ts-ignore when keycharm creates an index.d.ts file
+// @ts-ignore
 import keycharm from 'keycharm'
 export { keycharm }
 


### PR DESCRIPTION
If one has `"noImplicitAny": true` on their typescript project using this library, then typescript will throw an error because `keycharm` does not have a typings file. 

Adding @ts-ignore prevents typescript from throwing this error. 