### PR TITLE
fix: all lint errors

### DIFF
--- a/lib/timeline/.eslintrc
+++ b/lib/timeline/.eslintrc
@@ -24,7 +24,7 @@
             "FunctionDeclaration": true,
             "MethodDefinition": true,
             "ClassDeclaration": true,
-            "ArrowFunctionExpression": true
+            "ArrowFunctionExpression": false
         }
     }],
     "valid-jsdoc": [2, {

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -1067,6 +1067,9 @@ class Core {
     this.body.emitter.emit("changed");
   }
 
+  /**
+   * sets the basic DOM components needed for the timeline\graph2d
+   */
   _setDOM() {
     const props = this.props;
     const dom = this.dom;
@@ -1149,8 +1152,8 @@ class Core {
    * @param {int}     x    Position on the screen in pixels
    * @return {Date}   time The datetime the corresponds with given position x
    * @protected
+   * TODO: move this function to Range
    */
-  // TODO: move this function to Range
   _toTime(x) {
     return DateUtil.toTime(this, x, this.props.center.width);
   }
@@ -1160,8 +1163,8 @@ class Core {
    * @param {int}     x    Position on the screen in pixels
    * @return {Date}   time The datetime the corresponds with given position x
    * @protected
+   * TODO: move this function to Range
    */
-  // TODO: move this function to Range
   _toGlobalTime(x) {
     return DateUtil.toTime(this, x, this.props.root.width);
     //var conversion = this.range.conversion(this.props.root.width);
@@ -1174,8 +1177,8 @@ class Core {
    * @return {int}   x    The position on the screen in pixels which corresponds
    *                      with the given date.
    * @protected
+   * TODO: move this function to Range
    */
-  // TODO: move this function to Range
   _toScreen(time) {
     return DateUtil.toScreen(this, time, this.props.center.width);
   }
@@ -1187,8 +1190,8 @@ class Core {
    * @return {int}   x    The position on root in pixels which corresponds
    *                      with the given date.
    * @protected
+   * TODO: move this function to Range
    */
-  // TODO: move this function to Range
   _toGlobalScreen(time) {
     return DateUtil.toScreen(this, time, this.props.root.width);
     //var conversion = this.range.conversion(this.props.root.width);

--- a/lib/timeline/DateUtil.js
+++ b/lib/timeline/DateUtil.js
@@ -218,6 +218,10 @@ export function removeDuplicates(body) {
   body.hiddenDates.sort((a, b) => a.start - b.start); // sort by start time
 }
 
+/**
+ * Prints dates to console
+ * @param {array} dates
+ */
 export function printDates(dates) {
   for (let i =0; i < dates.length; i++) {
     console.log(i, new Date(dates[i].start),new Date(dates[i].end), dates[i].start, dates[i].end, dates[i].remove);
@@ -397,6 +401,14 @@ export function correctTimeForHidden(moment, hiddenDates, range, time) {
   return time;
 }
 
+/**
+ * Support function
+ * @param {function} moment
+ * @param {Array.<{start: Window.start, end: *}>} hiddenDates
+ * @param {{start: number, end: number}} range
+ * @param {Date} time
+ * @returns {number}
+ */
 export function getHiddenDurationBefore(moment, hiddenDates, range, time) {
   let timeOffset = 0;
   time = moment(time).toDate().valueOf();

--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -168,8 +168,8 @@ export default class Range extends Component {
 
   /**
    * Set a new start and end range
-   * @param {Date | number | string} [start]
-   * @param {Date | number | string} [end]
+   * @param {Date | number | string} start
+   * @param {Date | number | string} end
    * @param {Object} options      Available options:
    *                              {boolean | {duration: number, easingFunction: string}} [animation=false]
    *                                    If true, the range is animated
@@ -185,8 +185,8 @@ export default class Range extends Component {
    *                                    {number} easeCoefficient    an easing coefficent
    *                                    {boolean} willDraw          If true the caller will redraw after the callback completes
    *                                    {boolean} done              If true then animation is ending after the current frame
+   * @return {void}
    */
-
   setRange(start, end, options, callback, frameCallback) {
     if (!options) {
       options = {};

--- a/lib/timeline/Stack.js
+++ b/lib/timeline/Stack.js
@@ -141,7 +141,7 @@ export function substack(items, margin, subgroup) {
  *            Margins between items and between items and the axis.
  * @param {subgroups[]} subgroups
  *            All subgroups
- * @param {boolean} stackSubgroups
+ * @param {boolean} isStackSubgroups
  */
 export function nostack(items, margin, subgroups, isStackSubgroups) {
   for (let i = 0; i < items.length; i++) {

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -22,15 +22,17 @@ import util from 'vis-util';
  *
  * Version: 1.2
  *
- * @param {Date} [start]         The start date, for example new Date(2010, 9, 21)
- *                               or new Date(2010, 9, 21, 23, 45, 00)
- * @param {Date} [end]           The end date
- * @param {number} [minimumStep] Optional. Minimum step size in milliseconds
- * @param {Date|Array.<Date>} [hiddenDates] Optional.
- * @param {{showMajorLabels: boolean}} [options] Optional.
- * @constructor  TimeStep
  */
 class TimeStep {
+  /**
+    * @param {Date} [start]         The start date, for example new Date(2010, 9, 21)
+    *                               or new Date(2010, 9, 21, 23, 45, 00)
+    * @param {Date} [end]           The end date
+    * @param {number} [minimumStep] Optional. Minimum step size in milliseconds
+    * @param {Date|Array.<Date>} [hiddenDates] Optional.
+    * @param {{showMajorLabels: boolean}} [options] Optional.
+    * @constructor  TimeStep
+    */
   constructor(start, end, minimumStep, hiddenDates, options) {
     this.moment = moment;
 
@@ -591,6 +593,10 @@ class TimeStep {
     return (format && format.length > 0) ? this.moment(date).format(format) : '';
   }
 
+  /**
+   * get class name
+   * @return {string} class name
+   */
   getClassName() {
     const _moment = this.moment;
     const m = this.moment(this.current);

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -266,6 +266,10 @@ export default class Timeline extends Core {
     this._redraw();
   }
 
+  /**
+   * Remove an item from the group
+   * @param {object} options
+   */
   setOptions(options) {
     // validate options
     let errorFound = Validator.validate(options, allOptions);
@@ -725,10 +729,19 @@ export default class Timeline extends Core {
     }
   }
 
+  /**
+   * redraw
+   * @private
+   */
   _redraw() {
     Core.prototype._redraw.call(this);
   }
 
+  /**
+   * on fit callback
+   * @param {object} args
+   * @private
+   */
   _onFit(args) {
     const { start, end, animation } = args;
     if (!end) {

--- a/lib/timeline/component/ClusterGenerator.js
+++ b/lib/timeline/component/ClusterGenerator.js
@@ -66,9 +66,10 @@ export default class ClusterGenerator {
 
     /**
      * Cluster the items which are too close together
-     * @param {oldClusters: {maxItems: number, clusterCriteria: function, titleTemplate: string}} options 
-     * @param {scale: number} scale      The scale of the current window : (windowWidth / (endDate - startDate)) 
-     * @return {clusters: array} clusters
+     * @param {array} oldClusters 
+     * @param {number} scale      The scale of the current window : (windowWidth / (endDate - startDate)) 
+     * @param {{maxItems: number, clusterCriteria: function, titleTemplate: string}} options             
+     * @return {array} clusters
     */
     getClusters(oldClusters, scale, options) {
         let { maxItems, clusterCriteria } = typeof options === "boolean" ? {} : options;
@@ -224,11 +225,11 @@ export default class ClusterGenerator {
     /**
      * Create new cluster or return existing
      * @private
-     * @param {clusterItems: array} clusterItems    
-     * @param {group: object} group 
-     * @param {oldClusters: array} oldClusters 
-     * @param {options: object} options 
-     * @returns {cluster: object} cluster
+     * @param {array} clusterItems    
+     * @param {object} group 
+     * @param {array} oldClusters 
+     * @param {object} options 
+     * @returns {object} cluster
      */
     _getClusterForItems(clusterItems, group, oldClusters, options) {
         const oldClustersLookup = (oldClusters || []).map(cluster => ({

--- a/lib/timeline/component/CurrentTime.js
+++ b/lib/timeline/component/CurrentTime.js
@@ -5,6 +5,9 @@ import locales from '../locales';
 
 /**
  * A current time bar
+ */
+class CurrentTime extends Component {
+/**
  * @param {{range: Range, dom: Object, domProps: Object}} body
  * @param {Object} [options]        Available parameters:
  *                                  {Boolean} [showCurrentTime]
@@ -12,7 +15,6 @@ import locales from '../locales';
  * @constructor CurrentTime
  * @extends Component
  */
-class CurrentTime extends Component {
   constructor(body, options) {
     super()
     this.body = body;

--- a/lib/timeline/component/DataAxis.js
+++ b/lib/timeline/component/DataAxis.js
@@ -98,6 +98,11 @@ class DataAxis extends Component {
     });
   }
 
+  /**
+   * Adds group to data axis
+   * @param {string} label 
+   * @param {object} graphOptions
+   */
   addGroup(label, graphOptions) {
     if (!this.groups.hasOwnProperty(label)) {
       this.groups[label] = graphOptions;
@@ -105,6 +110,11 @@ class DataAxis extends Component {
     this.amountOfGroups += 1;
   }
 
+  /**
+   * updates group of data axis
+   * @param {string} label 
+   * @param {object} graphOptions
+   */
   updateGroup(label, graphOptions) {
     if (!this.groups.hasOwnProperty(label)) {
       this.amountOfGroups += 1;
@@ -112,6 +122,10 @@ class DataAxis extends Component {
     this.groups[label] = graphOptions;
   }
 
+  /**
+   * removes group of data axis
+   * @param {string} label 
+   */
   removeGroup(label) {
     if (this.groups.hasOwnProperty(label)) {
       delete this.groups[label];
@@ -119,6 +133,10 @@ class DataAxis extends Component {
     }
   }
 
+  /**
+   * sets options
+   * @param {object} options
+   */
   setOptions(options) {
     if (options) {
       let redraw = false;
@@ -176,6 +194,9 @@ class DataAxis extends Component {
     this.dom.frame.appendChild(this.svg);
   }
 
+  /**
+   * redraws groups icons
+   */
   _redrawGroupIcons() {
     DOMutil.prepareElements(this.svgElements);
 
@@ -206,6 +227,9 @@ class DataAxis extends Component {
     this.iconsRemoved = false;
   }
 
+  /**
+   * Cleans up icons
+   */
   _cleanupIcons() {
     if (this.iconsRemoved === false) {
       DOMutil.prepareElements(this.svgElements);
@@ -445,10 +469,20 @@ class DataAxis extends Component {
     return resized;
   }
 
+  /**
+   * converts value
+   * @param {number} value
+   * @returns {number} converted number
+   */
   convertValue(value) {
     return this.scale.convertValue(value);
   }
 
+  /**
+   * converts value
+   * @param {number} x
+   * @returns {number} screen value
+   */
   screenToValue(x) {
     return this.scale.screenToValue(x);
   }

--- a/lib/timeline/component/DataScale.js
+++ b/lib/timeline/component/DataScale.js
@@ -1,16 +1,17 @@
-/**
- *
- * @param {number} start
- * @param {number} end
- * @param {boolean} autoScaleStart
- * @param {boolean} autoScaleEnd
- * @param {number} containerHeight
- * @param {number} majorCharHeight
- * @param {boolean} zeroAlign
- * @param {function} formattingFunction
- * @constructor DataScale
- */
+/** DataScale */
 class DataScale {
+  /**
+   *
+   * @param {number} start
+   * @param {number} end
+   * @param {boolean} autoScaleStart
+   * @param {boolean} autoScaleEnd
+   * @param {number} containerHeight
+   * @param {number} majorCharHeight
+   * @param {boolean} zeroAlign
+   * @param {function} formattingFunction
+   * @constructor DataScale
+   */
   constructor(
     start,
     end,
@@ -64,14 +65,25 @@ class DataScale {
     }
   }
 
+  /**
+   * set chart height
+   * @param {number} majorCharHeight 
+   */
   setCharHeight(majorCharHeight) {
     this.majorCharHeight = majorCharHeight;
   }
 
+  /**
+   * set height
+   * @param {number} containerHeight 
+   */
   setHeight(containerHeight) {
     this.containerHeight = containerHeight;
   }
 
+  /**
+   * determine scale
+   */
   determineScale() {
     const range = this._end - this._start;
     this.scale = this.containerHeight / range;
@@ -105,19 +117,37 @@ class DataScale {
     }
   }
 
+  /**
+   * returns if value is major
+   * @param {number} value
+   * @returns {boolean} 
+   */
   is_major(value) {
     return (value % (this.magnitudefactor * this.majorSteps[this.minorStepIdx]) === 0);
   }
 
+  /**
+   * returns step size
+   * @returns {number} 
+   */
   getStep() {
     return this.magnitudefactor * this.minorSteps[this.minorStepIdx];
   }
 
+  /**
+   * returns first major
+   * @returns {number} 
+   */
   getFirstMajor() {
     const majorStep = this.magnitudefactor * this.majorSteps[this.minorStepIdx];
     return this.convertValue(this._start + ((majorStep - (this._start % majorStep)) % majorStep));
   }
 
+  /**
+   * returns first major
+   * @param {date} current
+   * @returns {date} formatted date
+   */
   formatValue(current) {
     let returnValue = current.toPrecision(5);
     if (typeof this.formattingFunction === 'function') {
@@ -136,6 +166,10 @@ class DataScale {
 
   }
 
+  /**
+   * returns lines
+   * @returns {object} lines
+   */
   getLines() {
     const lines = [];
     const step = this.getStep();
@@ -148,6 +182,10 @@ class DataScale {
     return lines;
   }
 
+  /**
+   * follow scale
+   * @param {object} other
+   */
   followScale(other) {
     const oldStepIdx = this.minorStepIdx;
     const oldStart = this._start;
@@ -242,10 +280,20 @@ class DataScale {
     }
   }
 
+  /**
+   * convert value
+   * @param {number} value
+   * @returns {number} 
+   */
   convertValue(value) {
     return this.containerHeight - ((value - this._start) * this.scale);
   }
 
+  /**
+   * returns screen to value
+   * @param {number} pixels
+   * @returns {number} 
+   */
   screenToValue(pixels) {
     return ((this.containerHeight - pixels) / this.scale) + this._start;
   }

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -257,6 +257,10 @@ class Group {
     return this.props.label.width;
   }
 
+  /**
+   * check if group has had an initial height hange
+   * @returns {boolean} 
+   */
   _didMarkerHeightChange() {
     const markerHeight = this.dom.marker.clientHeight;
     if (markerHeight != this.lastMarkerHeight) {
@@ -288,6 +292,10 @@ class Group {
     }
   }
 
+  /**
+   * calculate group dimentions and position
+   * @param {number} pixels
+   */
   _calculateGroupSizeAndPosition() {
     const offsetTop = this.dom.foreground.offsetTop;
     const offsetLeft = this.dom.foreground.offsetLeft;
@@ -297,6 +305,10 @@ class Group {
     this.width = offsetWidth;
   }
 
+  /**
+   * checks if should bail redraw of items
+   * @returns {boolean} should bail 
+   */
   _shouldBailItemsRedraw() {
     const me = this;
     const timeoutOptions = this.itemSet.options.onTimeout;
@@ -326,6 +338,14 @@ class Group {
     return bail;
   }
 
+  /**
+   * redraws items
+   * @param {boolean} forceRestack
+   * @param {boolean} lastIsVisible
+   * @param {number} margin
+   * @param {object} range
+   * @private
+   */
   _redrawItems(forceRestack, lastIsVisible, margin, range) {
     const restack = forceRestack || this.stackDirty || this.isVisible && !lastIsVisible;
 
@@ -425,6 +445,12 @@ class Group {
     }
   }
 
+  /**
+   * check if group resized
+   * @param {boolean} resized
+   * @param {number} height
+   * @return {boolean} did resize
+   */
   _didResize(resized, height) {
     resized = util.updateProperty(this, 'height', height) || resized;
     // recalculate size of label
@@ -435,13 +461,20 @@ class Group {
     return resized;
   }
 
+  /**
+   * apply group height
+   * @param {number} height
+   */
   _applyGroupHeight(height) {
     this.dom.background.style.height = `${height}px`;
     this.dom.foreground.style.height = `${height}px`;
     this.dom.label.style.height = `${height}px`;
   }
 
-  // update vertical position of items after they are re-stacked and the height of the group is calculated
+  /**
+   * update vertical position of items after they are re-stacked and the height of the group is calculated
+   * @param {number} margin
+   */
   _updateItemsVerticalPosition(margin) {
     for (let i = 0, ii = this.visibleItems.length; i < ii; i++) {
       const item = this.visibleItems[i];
@@ -535,7 +568,7 @@ class Group {
     if (Object.keys(this.subgroups).length > 0) {
       const me = this;
 
-      this.resetSubgroups();
+      this._resetSubgroups();
 
       util.forEach(this.visibleItems, item => {
         if (item.data.subgroup !== undefined) {
@@ -670,6 +703,11 @@ class Group {
     }
   }
 
+  /**
+   * add item to subgroup
+   * @param {object} item
+   * @param {string} subgroupId
+   */
   _addToSubgroup(item, subgroupId=item.data.subgroup) {
     if (subgroupId != undefined && this.subgroups[subgroupId] === undefined) {
       this.subgroups[subgroupId] = {
@@ -698,6 +736,9 @@ class Group {
     this.subgroups[subgroupId].items.push(item);
   }
 
+  /**
+   * update subgroup sizes
+   */
   _updateSubgroupsSizes() {
     const me = this;
     if (me.subgroups) {
@@ -724,6 +765,9 @@ class Group {
     }
   }
 
+  /**
+   * order subgroups
+   */
   orderSubgroups() {
     if (this.subgroupOrderer !== undefined) {
       const sortArray = [];
@@ -748,7 +792,10 @@ class Group {
     }
   }
 
-  resetSubgroups() {
+  /**
+   * add item to subgroup
+   */
+  _resetSubgroups() {
     for (const subgroup in this.subgroups) {
       if (this.subgroups.hasOwnProperty(subgroup)) {
         this.subgroups[subgroup].visible = false;
@@ -776,6 +823,11 @@ class Group {
     }
   }
 
+  /**
+   * remove item from subgroup
+   * @param {object} item
+   * @param {string} subgroupId
+   */
   _removeFromSubgroup(item, subgroupId=item.data.subgroup) {
     if (subgroupId != undefined) {
       const subgroup = this.subgroups[subgroupId];
@@ -922,6 +974,14 @@ class Group {
     return visibleItems;
   }
 
+  /**
+   * trace visible items in group
+   * @param {number} initialPos
+   * @param {array} items
+   * @param {aray} visibleItems
+   * @param {object} visibleItemsLookup
+   * @param {function} breakCondition
+   */
   _traceVisible(initialPos, items, visibleItems, visibleItemsLookup, breakCondition) {
     if (initialPos != -1) {
       for (let i = initialPos; i >= 0; i--) {
@@ -1003,6 +1063,14 @@ class Group {
     }
   }
 
+  /**
+   * Update the visible items
+   * @param {array} orderedClusters 
+   * @param {array} oldVisibleClusters                         
+   * @param {{start: number, end: number}} range             
+   * @return {Item[]} visibleItems                            
+   * @private
+   */
   _updateClustersInRange(orderedClusters, oldVisibleClusters, range) {
     // Clusters can overlap each other so we cannot use binary search here
     const visibleClusters = [];
@@ -1051,6 +1119,12 @@ class Group {
     return visibleClusters;
   }
 
+  /**
+   * change item subgroup
+   * @param {object} item
+   * @param {string} oldSubgroup
+   * @param {string} newSubgroup
+   */
   changeSubgroup(item, oldSubgroup, newSubgroup) {
     this._removeFromSubgroup(item, oldSubgroup);
     this._addToSubgroup(item, newSubgroup);

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -602,6 +602,7 @@ class ItemSet extends Component {
 
   /**
    * Activates the popup timer to show the given popup after a fixed time.
+   * @param {Popup} popup
    */
   setPopupTimer(popup) {
     this.clearPopupTimer();
@@ -733,6 +734,11 @@ class ItemSet extends Component {
     return ids;
   }
   
+  /**
+   * get item by id
+   * @param {string} id
+   * @return {object} item
+   */
   getItemById(id) {
     return this.items[id] || this.clusters.find(cluster => cluster.id === id);
   } 
@@ -1862,6 +1868,11 @@ class ItemSet extends Component {
     }
   }
 
+  /**
+   * On group click
+   * @param {Event} event
+   * @private
+   */
   _onGroupClick(event) {
     const group = this.groupFromTarget(event);
     setTimeout(() => {
@@ -1869,6 +1880,11 @@ class ItemSet extends Component {
     }, 1)
   }
   
+  /**
+   * Toggle show nested
+   * @param {object} group
+   * @param {boolean} force
+   */
   toggleGroupShowNested(group, force = undefined) {
 
     if (!group || !group.nestedGroups) return;
@@ -1918,11 +1934,21 @@ class ItemSet extends Component {
     }
   }
   
+  /**
+   * Toggle group drag classname
+   * @param {object} group
+   */
   toggleGroupDragClassName(group) {
     group.dom.label.classList.toggle('vis-group-is-dragging');
     group.dom.foreground.classList.toggle('vis-group-is-dragging');
   }
   
+  /**
+   * on drag start
+   * @param {Event} event
+   * @return {void}   
+   * @private
+   */
   _onGroupDragStart(event) {
     if (this.groupTouchParams.isDragging) return;
 
@@ -1942,6 +1968,12 @@ class ItemSet extends Component {
     }
   }
 
+  /**
+   * on drag
+   * @param {Event} event
+   * @return {void}
+   * @private
+   */
   _onGroupDrag(event) {
       if (this.options.groupEditable.order && this.groupTouchParams.group) {
           event.stopPropagation();
@@ -2045,6 +2077,12 @@ class ItemSet extends Component {
       }
   }
 
+  /**
+   * on drag end
+   * @param {Event} event
+   * @return {void}
+   * @private
+   */
   _onGroupDragEnd(event) {
     this.groupTouchParams.isDragging = false;
 
@@ -2188,6 +2226,12 @@ class ItemSet extends Component {
     });
   }
 
+  /**
+   * on mouse start
+   * @param {Event} event
+   * @return {void}   
+   * @private
+   */
   _onMouseOut(event) {
     const item = this.itemFromTarget(event);
     if (!item) return;
@@ -2210,6 +2254,12 @@ class ItemSet extends Component {
     });
   }
 
+  /**
+   * on mouse move
+   * @param {Event} event
+   * @return {void}   
+   * @private
+   */
   _onMouseMove(event) {
     const item = this.itemFromTarget(event);
     if (!item) return;
@@ -2588,6 +2638,11 @@ class ItemSet extends Component {
     return clone;
   }
 
+  /**
+   * cluster items
+   * @return {void}   
+   * @private
+   */
   _clusterItems() {
     if (!this.options.cluster) {
       return;
@@ -2610,6 +2665,10 @@ class ItemSet extends Component {
     }
   }
 
+  /**
+   * detach all cluster items
+   * @private
+   */
   _detachAllClusters() {
     if (this.options.cluster) {
       if (this.clusters && this.clusters.length) {
@@ -2620,6 +2679,11 @@ class ItemSet extends Component {
     }
   }
 
+  /**
+   * update clusters
+   * @param {array} clusters
+   * @private
+   */
   _updateClusters(clusters) {
     if (this.clusters && this.clusters.length) {
       const newClustersIds = new Set(clusters.map(cluster => cluster.id));

--- a/lib/timeline/component/item/BackgroundItem.js
+++ b/lib/timeline/component/item/BackgroundItem.js
@@ -49,6 +49,10 @@ class BackgroundItem extends Item {
     return (this.data.start < range.end) && (this.data.end > range.start); 
   }
 
+  /**
+   * create DOM element
+   * @private
+   */
   _createDomElement() {
     if (!this.dom) {
       // create DOM
@@ -76,6 +80,10 @@ class BackgroundItem extends Item {
     }
   }
 
+  /**
+   * append DOM element
+   * @private
+   */
   _appendDomElement() {
     if (!this.parent) {
       throw new Error('Cannot redraw item: no parent attached');
@@ -90,6 +98,10 @@ class BackgroundItem extends Item {
     this.displayed = true;
   }
 
+  /**
+   * update DOM Dirty components
+   * @private
+   */
   _updateDirtyDomComponents() {
     // update dirty DOM. An item is marked dirty when:
     // - the item is not yet rendered
@@ -107,6 +119,11 @@ class BackgroundItem extends Item {
     }
   }
 
+  /**
+   * get DOM components sizes
+   * @return {object}
+   * @private
+   */
   _getDomComponentsSizes() {
     // determine from css whether this box has overflow
     this.overflow = window.getComputedStyle(this.dom.content).overflow !== 'hidden';
@@ -117,6 +134,11 @@ class BackgroundItem extends Item {
     }
   }
 
+  /**
+   * update DOM components sizes
+   * @param {object} sizes
+   * @private
+   */
   _updateDomComponentsSizes(sizes) {
     // recalculate size
     this.props.content.width = sizes.content.width;
@@ -125,6 +147,10 @@ class BackgroundItem extends Item {
     this.dirty = false;
   }
 
+  /**
+   * repaint DOM additionals
+   * @private
+   */
   _repaintDomAdditionals() {
   }
 

--- a/lib/timeline/component/item/BoxItem.js
+++ b/lib/timeline/component/item/BoxItem.js
@@ -63,6 +63,10 @@ class BoxItem extends Item {
     return isVisible;
   }
 
+   /**
+   * create DOM element
+   * @private
+   */
   _createDomElement() {
     if (!this.dom) {
       // create DOM
@@ -91,6 +95,10 @@ class BoxItem extends Item {
     }
   }
 
+  /**
+   * append DOM element
+   * @private
+   */
   _appendDomElement() {
     if (!this.parent) {
       throw new Error('Cannot redraw item: no parent attached');
@@ -113,6 +121,10 @@ class BoxItem extends Item {
     this.displayed = true;
   }
 
+  /**
+   * update dirty DOM element
+   * @private
+   */
   _updateDirtyDomComponents() {
     // An item is marked dirty when:
     // - the item is not yet rendered
@@ -135,6 +147,11 @@ class BoxItem extends Item {
     }
   }
 
+  /**
+   * get DOM components sizes
+   * @return {object}
+   * @private
+   */
   _getDomComponentsSizes() {
     return {
       previous: {
@@ -155,6 +172,11 @@ class BoxItem extends Item {
     }
   }
 
+  /**
+   * update DOM components sizes
+   * @param {object} sizes
+   * @private
+   */
   _updateDomComponentsSizes(sizes) {
     if (this.options.rtl) {
       this.dom.box.style.right = "0px";
@@ -179,6 +201,10 @@ class BoxItem extends Item {
     this.dirty = false;
   }
 
+  /**
+   * repaint DOM additionals
+   * @private
+   */
   _repaintDomAdditionals() {
     this._repaintOnItemUpdateTimeTooltip(this.dom.box);
     this._repaintDragCenter();

--- a/lib/timeline/component/item/ClusterItem.js
+++ b/lib/timeline/component/item/ClusterItem.js
@@ -42,10 +42,18 @@ class ClusterItem extends Item {
     this.data.isCluster = true;
   }
 
+  /**
+   * check if there are items
+   * @return {boolean}
+   */
   hasItems() {
     return this.data.uiItems && this.data.uiItems.length && this.attached;
   }
   
+  /**
+   * set UI items
+   * @param {array} items
+   */
   setUiItems(items) {
     this.detach();
   
@@ -56,6 +64,11 @@ class ClusterItem extends Item {
     this.attach();
   }
   
+  /**
+   * check is visible
+   * @param {object} range
+   * @return {boolean}
+   */
   isVisible(range) {
     const rangeWidth = this.data.end ? this.data.end - this.data.start : 0;
     const widthInMs = this.width * range.getMillisecondsPerPixel();
@@ -63,6 +76,10 @@ class ClusterItem extends Item {
     return (this.data.start < range.end) && (end > range.start) && this.hasItems();
   }
   
+  /**
+   * get cluster data
+   * @return {object}
+   */
   getData() {
     return {
       isCluster: true,
@@ -72,6 +89,11 @@ class ClusterItem extends Item {
     }
   }
   
+  /**
+   * redraw cluster item
+   * @param {boolean} returnQueue
+   * @return {boolean}
+   */
   redraw (returnQueue) {
     var sizes
     var queue = [
@@ -111,6 +133,9 @@ class ClusterItem extends Item {
     }
   }
   
+  /**
+   * show cluster item
+   */
   show() {
     if (!this.displayed) {
       this.redraw();
@@ -139,6 +164,9 @@ class ClusterItem extends Item {
     }
   }
   
+  /**
+   * reposition item x axis
+   */
   repositionX() {
     let start = this.conversion.toScreen(this.data.start);
     let end = this.data.end ? this.conversion.toScreen(this.data.end) : 0;
@@ -159,6 +187,11 @@ class ClusterItem extends Item {
     }
   }
 
+  /**
+   * reposition item stype
+   * @param {date} start
+   * @param {date} end
+   */
   repositionStype(start, end) {
     this.dom.line.style.display = 'block';
     this.dom.dot.style.display = 'block';
@@ -172,6 +205,11 @@ class ClusterItem extends Item {
     }
   }
   
+  /**
+   * reposition x without ranges
+   * @param {date} start
+   * @param {string} align
+   */
   repositionXWithoutRanges(start, align) {
     // calculate left position of the box
     if (align == 'right') {
@@ -214,6 +252,11 @@ class ClusterItem extends Item {
     }
   }
   
+  /**
+   * reposition x with ranges
+   * @param {date} start
+   * @param {date} end
+   */
   repositionXWithRanges(start, end) {
     let boxWidth = Math.round(Math.max(end - start + 0.5, 1));
   
@@ -234,6 +277,9 @@ class ClusterItem extends Item {
     this.dom.box.style.width = boxWidth + 'px';
   }
   
+  /**
+   * reposition item y axis
+   */
   repositionY() {
     var orientation = this.options.orientation.item;
     var box = this.dom.box;
@@ -261,20 +307,34 @@ class ClusterItem extends Item {
       this.dom.dot.style.top = (-this.dom.dot.offsetHeight / 2) + 'px';
     }
   }
-  
+
+  /**
+   * get width left
+   * @return {number}
+   */
   getWidthLeft() {
     return this.width / 2;
   }
   
+  /**
+   * get width right
+   * @return {number}
+   */
   getWidthRight() {
     return this.width / 2;
   }
   
+  /**
+   * move cluster item
+   */
   move() {
     this.repositionX();
     this.repositionY();
   }
   
+  /**
+   * attach
+   */
   attach() {
     for (let item of this.data.uiItems) {
       item.cluster = this;
@@ -286,6 +346,11 @@ class ClusterItem extends Item {
     this.dirty = true;
   }
   
+  /**
+   * detach
+   * @param {boolean} detachFromParent
+   * @return {void}
+   */
   detach(detachFromParent = false) {
     if (!this.hasItems()) {
       return;
@@ -306,10 +371,16 @@ class ClusterItem extends Item {
     this.dirty = true;
   }
   
+  /**
+   * handle on double click
+   */
   _onDoubleClick() {
    this._fit();
   }
   
+  /**
+   * set range
+   */
   _setupRange() {
     const stats = this.data.uiItems.map(item => ({
       start: item.data.start.valueOf(),
@@ -331,6 +402,10 @@ class ClusterItem extends Item {
     }
   }
   
+  /**
+   * get UI items
+   * @return {array}
+   */
   _getUiItems() {
     if (this.data.uiItems && this.data.uiItems.length) {
       return this.data.uiItems.filter(item => item.cluster === this);
@@ -339,6 +414,9 @@ class ClusterItem extends Item {
     return [];
   }
   
+  /**
+   * create DOM element
+   */
   _createDomElement() {
     if (!this.dom) {
       // create DOM
@@ -376,6 +454,9 @@ class ClusterItem extends Item {
     }
   }
   
+  /**
+   * append element to DOM
+   */
   _appendDomElement() {
     if (!this.parent) {
       throw new Error('Cannot redraw item: no parent attached');
@@ -408,7 +489,9 @@ class ClusterItem extends Item {
     this.displayed = true;
   }
   
-  
+  /**
+   * update dirty DOM components
+   */
   _updateDirtyDomComponents() {
     // An item is marked dirty when:
     // - the item is not yet rendered
@@ -437,6 +520,10 @@ class ClusterItem extends Item {
     }
   }
   
+  /**
+   * get DOM components sizes
+   * @return {object}
+   */
   _getDomComponentsSizes() {
     return {
       previous: {
@@ -450,6 +537,10 @@ class ClusterItem extends Item {
     }
   }
   
+  /**
+   * update DOM components sizes
+   * @param {object} sizes
+   */
   _updateDomComponentsSizes(sizes) {
     if (this.options.rtl) {
       this.dom.box.style.right = "0px";
@@ -476,14 +567,27 @@ class ClusterItem extends Item {
     this.dirty = false;
   }
   
+  /**
+   * repaint DOM additional components
+   */
   _repaintDomAdditionals() {
     this._repaintOnItemUpdateTimeTooltip(this.dom.box);
   }
   
+  /**
+   * check is stripe visible
+   * @return {number}
+   * @private
+   */
   _isStipeVisible() {
     return this.minWidth >= this.width || !this.data.end;
   }
   
+  /**
+   * get fit range
+   * @return {object}
+   * @private
+   */
   _getFitRange() {
     const offset = 0.05*(this.data.max - this.data.min) / 2;
       return {
@@ -492,6 +596,10 @@ class ClusterItem extends Item {
       };
   }
   
+   /**
+   * fit
+   * @private
+   */
   _fit() {
     if (this.emitter) {
       const {fitStart, fitEnd} = this._getFitRange();
@@ -506,6 +614,11 @@ class ClusterItem extends Item {
     }
   }
 
+   /**
+   * get item data
+   * @return {object}
+   * @private
+   */
   _getItemData() {
     return this.data;
   }

--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -360,6 +360,11 @@ class Item {
     }
   }
 
+   /**
+   * get item data
+   * @return {object}
+   * @private
+   */
   _getItemData() {
     return this.parent.itemSet.itemsData.get(this.id);
   }

--- a/lib/timeline/component/item/PointItem.js
+++ b/lib/timeline/component/item/PointItem.js
@@ -53,6 +53,10 @@ class PointItem extends Item {
     return (this.data.start.getTime() + widthInMs > range.start ) && (this.data.start < range.end);
   }
 
+  /**
+   * create DOM element
+   * @private
+   */
   _createDomElement() {
     if (!this.dom) {
       // create DOM
@@ -78,6 +82,10 @@ class PointItem extends Item {
     }
   }
 
+  /**
+   * append DOM element
+   * @private
+   */
   _appendDomElement() {
     if (!this.parent) {
       throw new Error('Cannot redraw item: no parent attached');
@@ -92,6 +100,10 @@ class PointItem extends Item {
     this.displayed = true;
   }
 
+  /**
+   * update dirty DOM components
+   * @private
+   */
   _updateDirtyDomComponents() {
     // An item is marked dirty when:
     // - the item is not yet rendered
@@ -112,6 +124,11 @@ class PointItem extends Item {
     }
   }
 
+  /**
+   * get DOM component sizes
+   * @return {object}
+   * @private
+   */
   _getDomComponentsSizes() {
     return {
       dot:  {
@@ -129,6 +146,11 @@ class PointItem extends Item {
     }
   }
 
+  /**
+   * update DOM components sizes
+   * @param {array} sizes
+   * @private
+   */
   _updateDomComponentsSizes(sizes) {
     // recalculate size of dot and contents
     this.props.dot.width = sizes.dot.width;
@@ -158,6 +180,10 @@ class PointItem extends Item {
     this.dirty = false;
   }
 
+  /**
+   * Repain DOM additionals
+   * @private
+   */
   _repaintDomAdditionals() {
     this._repaintOnItemUpdateTimeTooltip(this.dom.point);
     this._repaintDragCenter();

--- a/lib/timeline/component/item/RangeItem.js
+++ b/lib/timeline/component/item/RangeItem.js
@@ -49,6 +49,10 @@ class RangeItem extends Item {
     return (this.data.start < range.end) && (this.data.end > range.start);
   }
 
+  /**
+   * create DOM elements
+   * @private
+   */
   _createDomElement() {
     if (!this.dom) {
       // create DOM
@@ -81,6 +85,10 @@ class RangeItem extends Item {
 
   }
 
+  /**
+   * append element to DOM
+   * @private
+   */
   _appendDomElement() {
     if (!this.parent) {
       throw new Error('Cannot redraw item: no parent attached');
@@ -95,6 +103,10 @@ class RangeItem extends Item {
     this.displayed = true;
   }
 
+  /**
+   * update dirty DOM components
+   * @private
+   */
   _updateDirtyDomComponents() {
     // update dirty DOM. An item is marked dirty when:
     // - the item is not yet rendered
@@ -119,6 +131,11 @@ class RangeItem extends Item {
     }
   }
 
+  /**
+   * get DOM component sizes
+   * @return {object}
+   * @private
+   */
   _getDomComponentsSizes() {
     // determine from css whether this box has overflow
     this.overflow = window.getComputedStyle(this.dom.frame).overflow !== 'hidden';
@@ -133,6 +150,11 @@ class RangeItem extends Item {
     }
   }
 
+  /**
+   * update DOM component sizes
+   * @param {array} sizes
+   * @private
+   */
   _updateDomComponentsSizes(sizes) {
     this.props.content.width = sizes.content.width;
     this.height = sizes.box.height;
@@ -140,6 +162,10 @@ class RangeItem extends Item {
     this.dirty = false;
   }
 
+  /**
+   * repaint DOM additional components
+   * @private
+   */
   _repaintDomAdditionals() {
     this._repaintOnItemUpdateTimeTooltip(this.dom.box);
     this._repaintDeleteButton(this.dom.box);


### PR DESCRIPTION
This PR fixes all lint errors created by js-docs missing in all files.
Note: I want to get rid of JSdoc completely. 
It is not used in our docs and TBH I find it completely useless.
I believe it was replaced by types from TS. 

I wanted to get the lint fixed for Version 6.0.0,  but in consideration that we will probably get rid of it completely in future versions - if you agree in future discussions. 