### PR TITLE
feat(timeline): add custom events for markers

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1901,12 +1901,12 @@ timeline.off('select', onSelect);
     </tr>
 
     <tr>
-      <td>markerinput</td>
+      <td>markerchange</td>
       <td>
         <ul>
           <li><code>id</code> (Number or String): custom time bar id which the marker is attached to.</li>
           <li><code>title</code> (Date): the marker title.</li>
-          <li><code>event</code> (Object): original event triggering the markerinput.</li>
+          <li><code>event</code> (Object): original event triggering the markerchange.</li>
         </ul>
       </td>
       <td>Fired when the marker title has been changed.
@@ -1915,12 +1915,12 @@ timeline.off('select', onSelect);
     </tr>
 
     <tr>
-      <td>markerchange</td>
+      <td>markerchanged</td>
       <td>
         <ul>
           <li><code>id</code> (Number or String): custom time bar id which the marker is attached to.</li>
           <li><code>title</code> (Date): the marker title.</li>
-          <li><code>event</code> (Object): original event triggering the markerchange.</li>
+          <li><code>event</code> (Object): original event triggering the markerchanged.</li>
         </ul>
       </td>
       <td>Fired when an alteration to the marker title is committed.

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1900,6 +1900,34 @@ timeline.off('select', onSelect);
       </td>
     </tr>
 
+    <tr>
+      <td>markerinput</td>
+      <td>
+        <ul>
+          <li><code>id</code> (Number or String): custom time bar id which the marker is attached to.</li>
+          <li><code>title</code> (Date): the marker title.</li>
+          <li><code>event</code> (Object): original event triggering the markerinput.</li>
+        </ul>
+      </td>
+      <td>Fired when the marker title has been changed.
+        Only available when the marker is editable.
+      </td>
+    </tr>
+
+    <tr>
+      <td>markerchange</td>
+      <td>
+        <ul>
+          <li><code>id</code> (Number or String): custom time bar id which the marker is attached to.</li>
+          <li><code>title</code> (Date): the marker title.</li>
+          <li><code>event</code> (Object): original event triggering the markerchange.</li>
+        </ul>
+      </td>
+      <td>Fired when an alteration to the marker title is committed.
+        Only available when the marker is editable.
+      </td>
+    </tr>
+
   </table>
 
   <h2 id="Editing_Items">Editing Items</h2>

--- a/lib/timeline/component/CustomTime.js
+++ b/lib/timeline/component/CustomTime.js
@@ -201,12 +201,12 @@ class CustomTime extends Component {
       marker.addEventListener('pointerdown', function () {
         marker.focus();
       });
-      marker.addEventListener('input', this._onMarkerInput.bind(this));
-      // The editable div element has no onchange event, so here emulates the onchange event.
+      marker.addEventListener('input', this._onMarkerChange.bind(this));
+      // The editable div element has no change event, so here emulates the change event.
       marker.title = title;
       marker.addEventListener('blur', function (event) {
         if (this.title != event.target.innerHTML) {
-          this._onMarkerChange(event);
+          this._onMarkerChanged(event);
           this.title = event.target.innerHTML;
         };
       }.bind(this));
@@ -283,8 +283,8 @@ class CustomTime extends Component {
    * @param {Event} event
    * @private
    */
-  _onMarkerInput(event) {
-    this.body.emitter.emit('markerinput', {
+  _onMarkerChange(event) {
+    this.body.emitter.emit('markerchange', {
       id: this.options.id,
       title: event.target.innerHTML,
       event
@@ -298,8 +298,8 @@ class CustomTime extends Component {
    * @param {Event} event
    * @private
    */
-  _onMarkerChange(event) {
-    this.body.emitter.emit('markerchange', {
+  _onMarkerChanged(event) {
+    this.body.emitter.emit('markerchanged', {
       id: this.options.id,
       title: event.target.innerHTML,
       event

--- a/lib/timeline/component/CustomTime.js
+++ b/lib/timeline/component/CustomTime.js
@@ -195,12 +195,15 @@ class CustomTime extends Component {
     marker.className = `vis-custom-time-marker`;
     marker.innerHTML = title;
     marker.style.position = 'absolute';
+
     if (editable) {
       marker.setAttribute('contenteditable', 'true');
       marker.addEventListener('pointerdown', function () {
         marker.focus();
       });
+      marker.addEventListener('input', this._onMarkerInput.bind(this));
     }
+
     this.bar.appendChild(marker);
   }
 
@@ -264,6 +267,21 @@ class CustomTime extends Component {
       event
     });
 
+    event.stopPropagation();
+  }
+
+  /**
+   * Perform input operating.
+   * @param {Event} event
+   * @private
+   */
+  _onMarkerInput(event) {
+    this.body.emitter.emit('markerinput', {
+      id: this.options.id,
+      title: event.target.innerHTML,
+      event
+    });
+      
     event.stopPropagation();
   }
 

--- a/lib/timeline/component/CustomTime.js
+++ b/lib/timeline/component/CustomTime.js
@@ -202,6 +202,14 @@ class CustomTime extends Component {
         marker.focus();
       });
       marker.addEventListener('input', this._onMarkerInput.bind(this));
+      // The editable div element has no onchange event, so here emulates the onchange event.
+      marker.title = title;
+      marker.addEventListener('blur', function (event) {
+        if (this.title != event.target.innerHTML) {
+          this._onMarkerChange(event);
+          this.title = event.target.innerHTML;
+        };
+      }.bind(this));
     }
 
     this.bar.appendChild(marker);
@@ -282,6 +290,21 @@ class CustomTime extends Component {
       event
     });
       
+    event.stopPropagation();
+  }
+
+  /**
+   * Perform change operating.
+   * @param {Event} event
+   * @private
+   */
+  _onMarkerChange(event) {
+    this.body.emitter.emit('markerchange', {
+      id: this.options.id,
+      title: event.target.innerHTML,
+      event
+    });
+
     event.stopPropagation();
   }
 


### PR DESCRIPTION
Closes #131 

This PR adds two custom events
* `markerchange`: fired when the marker title has been changed([demo](http://jsfiddle.net/cu978pq1/)).
* `markerchanged`: fired when an alteration to the marker title is committed([demo](http://jsfiddle.net/1cx8r0og/)).