### PR TITLE
ci: add build dependency to examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,7 @@ workflows:
       - examples:
           requires:
             - prepare
+            - build
 
       # Enable when the code base is ready.
       # - lint:


### PR DESCRIPTION
Otherwise dist is not saved and screenshots of empty canvases are taken.

Closes #143.