### PR TITLE
Make DataGroup compatible with TimelineGroup

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -119,11 +119,11 @@ export interface SubGroupVisibilityOptions {
 
 export interface DataGroup {
   className?: string;
-  content: string;
+  content: string | HTMLElement;
   id: IdType;
   options?: DataGroupOptions;
   style?: string;
-  subgroupOrder?: string | (() => void);
+  subgroupOrder?: string | ((a: any, b: any) => number);
   title?: string;
   nestedGroups?: IdType[];
   subgroupStack?: SubGroupStackOptions | boolean;


### PR DESCRIPTION
Currently a variable of type `TimelineGroup[]` cannot be used in the constructor for `Timeline` nor the `setData` method.

`TimelineGroup.content` is of type `string | HTMLElement` which is currently not assignable to `DataGroupCollectionType.content`. However the docs say a group can contain an `HTMLElement`.

A Timeline Group's `subgroupOrder` function accepts a string or a sort function. The `TimelineGroup`'s function `(a: any, b: any) => number`  does not match the `DataGroup`'s function `() => void`. `DataGroup`'s function was changed to be a sort function like `TimelineGroup`.

Now a `TimelineGroup[]` can be used in the constructor to make a `Timeline`.

The other option would be to set `Timeline`'s constructor to TimelineGroup instead of DataGroup and all methods as well.
