### PR TITLE
Resolve 156: Subgroups overlap when scrolling vertically

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -515,7 +515,7 @@ class Group {
       () => {
         this.isVisible = this._isGroupVisible.bind(this)(range, margin);
       },
-
+      
       () => {
         this._redrawItems.bind(this)(forceRestack, lastIsVisible, margin, range)
       },

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -505,6 +505,9 @@ class Group {
       () => {
         forceRestack = this._didMarkerHeightChange.call(this) || forceRestack;
       },
+      
+      // recalculate the height of the subgroups
+      this._updateSubGroupHeights.bind(this, margin),
 
       // calculate actual size and position
       this._calculateGroupSizeAndPosition.bind(this),

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -384,9 +384,11 @@ class Group {
 
           stack.stackSubgroupsWithInnerStack(visibleSubgroups, margin, this.subgroups);
           this.visibleItems = getVisibleItems();
+          this._updateSubGroupHeights(margin);
         }
         else {
           this.visibleItems = getVisibleItems();
+          this._updateSubGroupHeights(margin);
           // order all items and force a restacking
            // order all items outside clusters and force a restacking
           const customOrderedItems = this.visibleItems 
@@ -402,6 +404,7 @@ class Group {
         const visibleItems = this._updateItemsInRange(orderedItems, this.visibleItems.filter(item => !item.isCluster), range);
         const visibleClusters = this._updateClustersInRange(orderedClusters, this.visibleItems.filter(item => item.isCluster), range);
         this.visibleItems = [...visibleItems, ...visibleClusters];
+        this._updateSubGroupHeights(margin);
 
         if (this.itemSet.options.stack) {
           if (this.doInnerStack && this.itemSet.options.stackSubgroups) {
@@ -502,9 +505,6 @@ class Group {
       () => {
         forceRestack = this._didMarkerHeightChange.call(this) || forceRestack;
       },
-
-      // recalculate the height of the subgroups
-      this._updateSubGroupHeights.bind(this, margin),
 
       // calculate actual size and position
       this._calculateGroupSizeAndPosition.bind(this),


### PR DESCRIPTION
**Problem:** 

This line (in Group.js)

```
stack.nostack(this.visibleItems, margin, this.subgroups, this.itemSet.options.stackSubgroups);
```
in the function `_redrawItems` uses the `this.subgroups` `top` and `height` properties to set its items `top` property.

Since `_updateSubGroupHeights` is called before `this.visibleItems` is set in `_redrawItems`, then the subgroups height and visible are 0 and false accordingly which sets the items in the 2nd+ subgroups items top property to be 0 and thus overlap all the items in the group.

**Soution:**

Call `_updateSubGroupHeights` after setting `this.visibleItems` but before `stack.nostack(...`

I took the function `_updateSubGroupHeights` out of the redraw queue and called it each time `this.visibleItems` was set in `_redrawItems`.

This seems to fix the problem but I am not sure if this will cause any unwanted side-effects since `_updateSubGroupHeights` is not guaranteed to be called each group redraw.

Any suggestions on improvements would be appreciated!

Demo:
![defect_fix_subgroupoverlay](https://user-images.githubusercontent.com/30392170/67579892-58564980-f713-11e9-8d58-61714a293bde.gif)
