### PR TITLE
feat(timeline): extend existing locales

### DIFF
--- a/lib/timeline/component/CurrentTime.js
+++ b/lib/timeline/component/CurrentTime.js
@@ -30,11 +30,20 @@ class CurrentTime extends Component {
       locale: 'en'
     };
     this.options = util.extend({}, this.defaultOptions);
+    this.setOptions(options);
+    util.extend(this.options.locales, locales, this.options.locales);
+    const defaultLocales = this.defaultOptions.locales[this.defaultOptions.locale];
+    Object.keys(this.options.locales).forEach(locale => {
+      this.options.locales[locale] = util.extend(
+        {},
+        defaultLocales,
+        this.options.locales[locale]
+      );
+    });
     this.offset = 0;
 
     this._create();
 
-    this.setOptions(options);
   }
 
   /**

--- a/lib/timeline/component/CustomTime.js
+++ b/lib/timeline/component/CustomTime.js
@@ -30,6 +30,16 @@ class CustomTime extends Component {
       title: undefined
     };
     this.options = util.extend({}, this.defaultOptions);
+    this.setOptions(options);
+    util.extend(this.options.locales, locales, this.options.locales);
+    const defaultLocales = this.defaultOptions.locales[this.defaultOptions.locale];
+    Object.keys(this.options.locales).forEach(locale => {
+      this.options.locales[locale] = util.extend(
+        {},
+        defaultLocales,
+        this.options.locales[locale]
+      );
+    });
 
     if (options && options.time) {
       this.customTime = options.time;
@@ -38,8 +48,6 @@ class CustomTime extends Component {
     }
 
     this.eventParams = {}; // stores state parameters while dragging the bar
-
-    this.setOptions(options);
 
     // create the DOM
     this._create();

--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -29,6 +29,15 @@ class Item {
       locale: 'en'
     };
     this.options = util.extend({}, this.defaultOptions, options);
+    util.extend(this.options.locales, locales, this.options.locales);
+    const defaultLocales = this.defaultOptions.locales[this.defaultOptions.locale];
+    Object.keys(this.options.locales).forEach(locale => {
+      this.options.locales[locale] = util.extend(
+        {},
+        defaultLocales,
+        this.options.locales[locale]
+      );
+    });
     this.selected = false;
     this.displayed = false;
     this.groupShowing = true;


### PR DESCRIPTION
Extend existing locales instead of replacing them. Fix #55.

This also extends all locales to use the default locale for any
missing key. So if a new localization option is added in the future,
every locale which does not yet have the new option translated will use
the default english one.
