### PR TITLE
Make 'template' optional in 'TimelineTooltipOption'

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -220,7 +220,7 @@ export interface TimelineTooltipOption {
   followMouse?: boolean;
   overflowMethod?: 'cap' | 'flip' | 'none';
   delay?: number;
-  template: (item: TimelineItem, editedData?: TimelineItem) => string;
+  template?: (item: TimelineItem, editedData?: TimelineItem) => string;
 }
 
 export type TimelineOptionsConfigureFunction = (option: string, path: string[]) => boolean;


### PR DESCRIPTION
`TimelineTooltipOption` requires you to define a `template`, but it already has a default value in the documentation. Not specifying the `template` still works as expected when changing the type to an optional and not defining it.