### PR TITLE
fix: updated hammerjs to 2.0.16 to include shadom-dom fix (visjs#116)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1110,9 +1110,9 @@
       }
     },
     "@egjs/hammerjs": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.15.tgz",
-      "integrity": "sha512-BysW5KdNiJ1Qq4JRILaX/Lx2eJGyVPsFSwKA3aJbY+SKv57lS5ZFbEdlgj5shfYPLeJGEnK1WjfleDT+y4s1aQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.16.tgz",
+      "integrity": "sha512-FoNZODUsvRNx98ep4/Qc1uojddZF+YKC714WB3PH+6eRHZwk3eRObHkmHmVI5+VyJJTfFp+dF1Zs3RdrZJEHUA==",
       "requires": {
         "@types/hammerjs": "^2.0.36"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     }
   },
   "dependencies": {
-    "@egjs/hammerjs": "2.0.15",
+    "@egjs/hammerjs": "2.0.16",
     "emitter-component": "1.1.1",
     "keycharm": "^0.3.0",
     "moment": "2.24.0",


### PR DESCRIPTION
Updated hammerjs to include their fix for shadow-dom support. Refer to the original visjs ticket and related hammerjs ticket for details.