### PR TITLE
fix: border calculations in browser zoom bugs

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -936,29 +936,13 @@ class Core {
     dom.root.style.maxHeight = util.option.asSize(options.maxHeight, '');
     dom.root.style.minHeight = util.option.asSize(options.minHeight, '');
     dom.root.style.width = util.option.asSize(options.width, '');
-
-    const rootClientHeight = dom.root.clientHeight;
-    const rootOffsetHeight = dom.root.offsetHeight;
     const rootOffsetWidth = dom.root.offsetWidth;
-    const centerContainerClientHeight =  dom.centerContainer.clientHeight;
 
     // calculate border widths
-    props.border.left   = Math.floor((dom.centerContainer.offsetWidth - dom.centerContainer.clientWidth) / 2);
-    props.border.right  = props.border.left;
-    props.border.top    = Math.floor((dom.centerContainer.offsetHeight - centerContainerClientHeight) / 2);
-    props.border.bottom = props.border.top;
-    props.borderRootHeight = rootOffsetHeight - rootClientHeight;
-    props.borderRootWidth = rootOffsetWidth - dom.root.clientWidth;
-
-    // workaround for a bug in IE: the clientWidth of an element with
-    // a height:0px and overflow:hidden is not calculated and always has value 0
-    if (centerContainerClientHeight === 0) {
-      props.border.left = props.border.top;
-      props.border.right  = props.border.left;
-    }
-    if (rootClientHeight  === 0) {
-      props.borderRootWidth = props.borderRootHeight;
-    }
+    props.border.left = 1
+    props.border.right = 1
+    props.border.top = 1
+    props.border.bottom = 1
 
     // calculate the heights. If any of the side panels is empty, we set the height to
     // minus the border width, such that the border will be invisible
@@ -973,22 +957,20 @@ class Core {
     // apply auto height
     // TODO: only calculate autoHeight when needed (else we cause an extra reflow/repaint of the DOM)
     const contentHeight = Math.max(props.left.height, props.center.height, props.right.height);
-    const autoHeight = props.top.height + contentHeight + props.bottom.height +
-      props.borderRootHeight + props.border.top + props.border.bottom;
+    const autoHeight = props.top.height + contentHeight + props.bottom.height + props.border.top + props.border.bottom;
     dom.root.style.height = util.option.asSize(options.height, `${autoHeight}px`);
 
     // calculate heights of the content panels
     props.root.height = dom.root.offsetHeight;
-    props.background.height = props.root.height - props.borderRootHeight;
-    const containerHeight = props.root.height - props.top.height - props.bottom.height -
-      props.borderRootHeight;
+    props.background.height = props.root.height;
+    const containerHeight = props.root.height - props.top.height - props.bottom.height;
     props.centerContainer.height  = containerHeight;
     props.leftContainer.height    = containerHeight;
     props.rightContainer.height   = props.leftContainer.height;
 
     // calculate the widths of the panels
     props.root.width = rootOffsetWidth;
-    props.background.width = props.root.width - props.borderRootWidth;
+    props.background.width = props.root.width;
 
     if (!this.initialDrawDone) {
       props.scrollbarWidth = util.getScrollBarWidth();
@@ -1092,7 +1074,7 @@ class Core {
 
     props.leftContainer.width = props.left.width;
     props.rightContainer.width = props.right.width;
-    const centerWidth = props.root.width - props.left.width - props.right.width - props.borderRootWidth;
+    const centerWidth = props.root.width - props.left.width - props.right.width;
     props.center.width          = centerWidth;
     props.centerContainer.width = centerWidth;
     props.top.width             = centerWidth;


### PR DESCRIPTION
This should solve #213 once and for all!
The border calculations done are really not needed... 
They were used in the past for various reasons that are irrelevant now. 
I've simplified the calculations to be constantly 1px and thus will no longer be dependent on `clientHeight` and `offsetHeight` which are very unstable in their returns due to being dependent on how the browser rounding.