### PR TITLE
Week options missing from graph2d options

### DIFF
--- a/docs/graph2d/index.html
+++ b/docs/graph2d/index.html
@@ -866,6 +866,7 @@ function (option, path) {
     hour:       'HH:mm',
     weekday:    'ddd D',
     day:        'D',
+    week:       'w',
     month:      'MMM',
     year:       'YYYY'
   },
@@ -876,6 +877,7 @@ function (option, path) {
     hour:       'ddd D MMMM',
     weekday:    'MMMM YYYY',
     day:        'MMMM YYYY',
+    week:       'MMMM YYYY',
     month:      'YYYY',
     year:       ''
   }

--- a/lib/timeline/optionsGraph2d.js
+++ b/lib/timeline/optionsGraph2d.js
@@ -112,6 +112,7 @@ let allOptions = {
       hour: {string,'undefined': 'undefined'},
       weekday: {string,'undefined': 'undefined'},
       day: {string,'undefined': 'undefined'},
+      week: {string,'undefined': 'undefined'},
       month: {string,'undefined': 'undefined'},
       quarter: {string,'undefined': 'undefined'},
       year: {string,'undefined': 'undefined'},
@@ -124,6 +125,7 @@ let allOptions = {
       hour: {string,'undefined': 'undefined'},
       weekday: {string,'undefined': 'undefined'},
       day: {string,'undefined': 'undefined'},
+      week: {string,'undefined': 'undefined'},
       month: {string,'undefined': 'undefined'},
       quarter: {string,'undefined': 'undefined'},
       year: {string,'undefined': 'undefined'},
@@ -239,6 +241,7 @@ let configureOptions = {
         hour:       'HH:mm',
         weekday:    'ddd D',
         day:        'D',
+        week:       'w',
         month:      'MMM',
         quarter:    '[Q]Q',
         year:       'YYYY'
@@ -250,6 +253,7 @@ let configureOptions = {
         hour:       'ddd D MMMM',
         weekday:    'MMMM YYYY',
         day:        'MMMM YYYY',
+        week:       'MMMM YYYY',
         month:      'YYYY',
         quarter:    'YYYY',
         year:       ''


### PR DESCRIPTION
I still need to update docs, but opening this early as a pseudo issue report too.

I noticed that the week option wasn't available on Graph2D. I think I used it previously but looking through the git history I must be mistaken.

Commit 65060a0f394d720d3f51e81efcc17a8154332fcd introduced the week options for Timeline but not Graph2D. I experimented and the only thing missing is adding it into the options from the looks of it. I copied and pasted the lines across and then my Graph2D worked just like I wanted it too.

Is there anything else I'm missing?

Otherwise I need to update docs. Do I also need to provide an example?