### PR TITLE
fix: a is not defined in this example.

### DIFF
--- a/examples/timeline/groups/verticalItemsHide.html
+++ b/examples/timeline/groups/verticalItemsHide.html
@@ -30,6 +30,7 @@
 
 <script>
   function showVisibleItems() {
+    var a = timeline.getVisibleItems();
     document.getElementById("visibleItemsContainer").innerHTML = ""
     document.getElementById("visibleItemsContainer").innerHTML += a;
   };

--- a/examples/timeline/groups/verticalItemsHide.html
+++ b/examples/timeline/groups/verticalItemsHide.html
@@ -30,9 +30,9 @@
 
 <script>
   function showVisibleItems() {
-    var a = timeline.getVisibleItems();
+    var visibleItems = timeline.getVisibleItems();
     document.getElementById("visibleItemsContainer").innerHTML = ""
-    document.getElementById("visibleItemsContainer").innerHTML += a;
+    document.getElementById("visibleItemsContainer").innerHTML += visibleItems;
   };
 
   // get selected item count from url parameter


### PR DESCRIPTION
 `examples/timeline/groups/verticalItemsHide.html`  has a mistake: 'a is not defined'.