### PR TITLE
fix: updated hammerjs to 2.0.17 for regression on IE/Edge (visjs#116)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1110,9 +1110,9 @@
       }
     },
     "@egjs/hammerjs": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.16.tgz",
-      "integrity": "sha512-FoNZODUsvRNx98ep4/Qc1uojddZF+YKC714WB3PH+6eRHZwk3eRObHkmHmVI5+VyJJTfFp+dF1Zs3RdrZJEHUA==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
       "requires": {
         "@types/hammerjs": "^2.0.36"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     }
   },
   "dependencies": {
-    "@egjs/hammerjs": "2.0.16",
+    "@egjs/hammerjs": "2.0.17",
     "emitter-component": "1.1.1",
     "keycharm": "^0.3.0",
     "moment": "2.24.0",


### PR DESCRIPTION
Updated hammerjs to 2.0.17 to fix a regression introduced in 2.0.16 that was included with PR (https://github.com/visjs/vis-timeline/pull/214). The regression prevented group and item selection in IE and Edge.