### PR TITLE
Add description for cluster.titleTemplate in docs

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1153,7 +1153,7 @@ function (option, path) {
       <td class="indent">cluster.titleTemplate</td>
       <td>string or null</td>
       <td><code>none</code></td>
-      <td>Cluster item tooltip</td>
+      <td>Cluster item tooltip, will replace <code>{count}</code> with the number of items in the cluster</td>
     </tr>
     <tr parent="cluster" class="hidden">
       <td class="indent">cluster.clusterCriteria</td>


### PR DESCRIPTION
cluster.titleTemplate documentation doesn't mention `{count}` which it will replace by the number of items in the cluster. Adding this in the documentation.