### PR TITLE
Catch when navigator is undefined - fixes #231

### DIFF
--- a/lib/DOMutil.js
+++ b/lib/DOMutil.js
@@ -224,10 +224,15 @@ export function drawBar (x, y, width, height, className, JSONcontainer, svgConta
  * @returns {string}
  */
 export function getNavigatorLanguage() {
-  if (!navigator) return 'en';
-  if (navigator.languages && navigator.languages.length) {
-    return navigator.languages;
-  } else {
-    return navigator.userLanguage || navigator.language || navigator.browserLanguage || 'en';
+  try{
+    if (!navigator) return 'en';
+    if (navigator.languages && navigator.languages.length) {
+      return navigator.languages;
+    } else {
+      return navigator.userLanguage || navigator.language || navigator.browserLanguage || 'en';
+    }
+  } 
+  catch(error) {
+    return 'en';
   }
 }

--- a/lib/DOMutil.js
+++ b/lib/DOMutil.js
@@ -224,7 +224,7 @@ export function drawBar (x, y, width, height, className, JSONcontainer, svgConta
  * @returns {string}
  */
 export function getNavigatorLanguage() {
-  try{
+  try {
     if (!navigator) return 'en';
     if (navigator.languages && navigator.languages.length) {
       return navigator.languages;


### PR DESCRIPTION
`if (!navigator)` throws an error when `navigator` has never been declared before such as with Node / Next.js.

Another option is to to check `typeof navigator === 'undefined'`. I chose to do a try...catch because I also want it to return `en` for any falsy value and not just `undefined` (if `navigator` were declared, but `null` for example).