### PR TITLE
fix: check if both updateGroup and updateTime are falsey - fixes #202

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -2292,9 +2292,7 @@ class ItemSet extends Component {
    */
   _onUpdateItem(item) {
     if (!this.options.selectable) return;
-    if (!this.options.editable.updateTime) return;
-    if (!this.options.editable.updateGroup) return;
-
+    if (!this.options.editable.updateTime && !this.options.editable.updateGroup) return;
 
     const me = this;
    


### PR DESCRIPTION
This is to fix: https://github.com/visjs/vis-timeline/issues/202

Check if both editable options are true instead of one by one
