### PR TITLE
fix: collisionByTimes updated to be exclusive

### DIFF
--- a/lib/timeline/Stack.js
+++ b/lib/timeline/Stack.js
@@ -80,14 +80,14 @@ export function stack(items, margin, force, shouldBailItemsRedrawFunction) {
 }
 
 /**
- * Adjust vertical positions of the items within a single subgroup such that they 
+ * Adjust vertical positions of the items within a single subgroup such that they
  * don't overlap each other.
  * @param {Item[]} items
  *            All items withina subgroup
  * @param {{item: {horizontal: number, vertical: number}, axis: number}} margin
  *            Margins between items and between items and the axis.
  * @param {subgroup} subgroup
- *            The subgroup that is being stacked 
+ *            The subgroup that is being stacked
  */
 export function substack(items, margin, subgroup) {
   for (var i = 0; i < items.length; i++) {
@@ -212,11 +212,11 @@ export function stackSubgroups(items, margin, subgroups) {
  * @param {{item: {horizontal: number, vertical: number}, axis: number}} margin
  *            Margins between items and between items and the axis.
  * @param {subgroups[]} subgroups
- *            All subgroups 
+ *            All subgroups
  */
 export function stackSubgroupsWithInnerStack(subgroupItems, margin, subgroups) {
   let doSubStack = false;
-  
+
   // Run subgroups in their order (if any)
   const subgroupOrder = [];
 
@@ -234,7 +234,7 @@ export function stackSubgroupsWithInnerStack(subgroupItems, margin, subgroups) {
     if (subgroups.hasOwnProperty(subgroup)) {
 
       doSubStack = doSubStack || subgroups[subgroup].stack;
-      subgroups[subgroup].top = 0;      
+      subgroups[subgroup].top = 0;
 
       for (const otherSubgroup in subgroups) {
         if (subgroups[otherSubgroup].visible && subgroups[subgroup].index > subgroups[otherSubgroup].index) {
@@ -248,16 +248,16 @@ export function stackSubgroupsWithInnerStack(subgroupItems, margin, subgroups) {
           items[i].top = subgroups[items[i].data.subgroup].top + 0.5 * margin.item.vertical;
 
           if (subgroups[subgroup].stack) {
-            items[i].baseTop = items[i].top;              
+            items[i].baseTop = items[i].top;
           }
-        } 
+        }
       }
 
       if (doSubStack && subgroups[subgroup].stack) {
-        substack(subgroupItems[subgroup], margin, subgroups[subgroup]);        
+        substack(subgroupItems[subgroup], margin, subgroups[subgroup]);
       }
     }
-  }    
+  }
 }
 
 /**
@@ -293,6 +293,10 @@ export function collision(a, b, margin, rtl) {
  * @return {boolean}        true if a and b collide, else false
  */
 export function collisionByTimes(a, b) {
-  return (a.start <= b.start && a.end >= b.start && a.top < (b.top + b.height) && (a.top + a.height) > b.top ) ||
-  (b.start <= a.start && b.end >= a.start && b.top < (a.top + a.height) && (b.top + b.height) > a.top );
+
+  // Check for overlap by time and height. Abutting is OK and
+  // not considered a collision while overlap is considered a collision.
+  const timeOverlap = a.start < b.end && a.end > b.start;
+  const heightOverlap = a.top < (b.top + b.height) && (a.top + a.height) > b.top;
+  return timeOverlap && heightOverlap;
 }


### PR DESCRIPTION
fixes #343

Modified collisionByTimes to be exclusive and not consider abutting items as colliding. See original ticket for an example.