### PR TITLE
fix(#373): check for showStipes option when getting DOM sizes in ClusterItem

### DIFF
--- a/lib/timeline/component/item/ClusterItem.js
+++ b/lib/timeline/component/item/ClusterItem.js
@@ -533,23 +533,28 @@ class ClusterItem extends Item {
    * @return {object}
    */
   _getDomComponentsSizes() {
-    return {
+    const sizes = {
       previous: {
         right: this.dom.box.style.right,
         left: this.dom.box.style.left
-      },
-      dot: {
-        height: this.dom.dot.offsetHeight,
-        width: this.dom.dot.offsetWidth
-      },
-      line: {
-        width: this.dom.line.offsetWidth
       },
       box: {
         width: this.dom.box.offsetWidth,
         height: this.dom.box.offsetHeight
       },
+    };
+
+    if (this.options.showStipes) {
+      sizes.dot = {
+        height: this.dom.dot.offsetHeight,
+        width: this.dom.dot.offsetWidth
+      };
+      sizes.line = {
+        width: this.dom.line.offsetWidth
+      };
     }
+
+    return sizes;
   }
   
   /**


### PR DESCRIPTION
fixes: #373 