### PR TITLE
[ts] snap not declared properly (null not allowed)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -226,6 +226,7 @@ export type TimelineOptionsItemsAlwaysDraggableType = boolean | TimelineItemsAlw
 export type TimelineOptionsMarginType = number | TimelineMarginOption;
 export type TimelineOptionsOrientationType = string | TimelineOrientationOption;
 export type TimelineOptionsSnapFunction = (date: Date, scale: string, step: number) => Date | number;
+export type TimelineOptionsSnapType = null | TimelineOptionsSnapFunction;
 export type TimelineOptionsTemplateFunction = (item?: any, element?: any, data?: any) => string;
 export type TimelineOptionsComparisonFunction = (a: any, b: any) => number;
 export type TimelineOptionsGroupHeightModeType = 'auto' | 'fixed' | 'fitItems';
@@ -296,7 +297,7 @@ export interface TimelineOptions {
   showTooltips?: boolean;
   stack?: boolean;
   stackSubgroups?: boolean;
-  snap?: TimelineOptionsSnapFunction;
+  snap?: TimelineOptionsSnapType;
   start?: DateType;
   template?: TimelineOptionsTemplateFunction;
   visibleFrameTemplate?: TimelineOptionsTemplateFunction;


### PR DESCRIPTION
https://visjs.github.io/vis-timeline/docs/timeline/#Configuration_Options

snap
When moving items on the Timeline, they will be snapped to nice dates like full hours or days, depending on the current scale.
The snap function can be replaced with a custom function, or can be set to null to disable snapping

before: null not allowed
after: null allowed

**Thank you for contributing to vis.js!!**

Please make sure to check the following requirements before creating a pull request:

* [x] All pull requests must be to the [master branch](https://github.com/visjs/vis-timeline/tree/master).
* [x] Make sure your changes are based on the latest version of the [master branch](https://github.com/visjs/vis-timeline/tree/master). (Use e.g. `git fetch && git rebase origin master` to update your feature branch).
* [ ] Provide an additional or update an example to demonstrate your changes or new features.
* [ ] Update the documentation if you introduced new behavior or changed existing behavior.
* [ ] Reference issue numbers of issues that your pull request addresses. (If you write something like `fixes #1781` in your git commit message this issue gets closed automatically by merging your pull request).
* [ ] Expect review comments and change requests by reviewer.
* [ ] Delete this checklist from your pull request.
