### PR TITLE
fix: ReferenceError due to access 'title' before initialization

### DIFF
--- a/lib/timeline/component/ClusterGenerator.js
+++ b/lib/timeline/component/ClusterGenerator.js
@@ -268,8 +268,8 @@ export default class ClusterGenerator {
             toTime: this.itemSet.body.util.toTime
         };
 
-        const clusterContent = '<div title="' + title + '">' + clusterItems.length + '</div>';
         const title = titleTemplate.replace(/{count}/, clusterItems.length);
+        const clusterContent = '<div title="' + title + '">' + clusterItems.length + '</div>';
         const clusterOptions = Object.assign({}, options, this.itemSet.options);
         const data = {
             'content': clusterContent,


### PR DESCRIPTION
Title was being accessed before its init causing:

```txt
ERROR ReferenceError: Cannot access 'title' before initialization
```
