### PR TITLE
Background items are not appearing during drag to the left in some cases

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -925,9 +925,11 @@ class Group {
     };
 
     // this function is used to do the binary search for items having start and end dates (range).
-    const endSearchFunction = value => {
-      if      (value < lowerBound)  {return -1;}
-      else                          {return  0;}
+    const endSearchFunction = data => {
+      const {start, end} = data;
+      if      (end < lowerBound)    {return -1;}
+      else if (start <= upperBound) {return  0;}
+      else                          {return  1;}
     }
 
     // first check if the items that were in view previously are still in view.
@@ -955,7 +957,7 @@ class Group {
     }
     else {
       // we do a binary search for the items that have defined end times.
-      const initialPosByEnd = util.binarySearchCustom(orderedItems.byEnd, endSearchFunction, 'data','end');
+      const initialPosByEnd = util.binarySearchCustom(orderedItems.byEnd, endSearchFunction, 'data');
 
       // trace the visible items from the inital start pos both ways until an invisible item is found, we only look at the end values.
       this._traceVisible(initialPosByEnd, orderedItems.byEnd, visibleItems, visibleItemsLookup, item => item.data.end < lowerBound || item.data.start > upperBound);


### PR DESCRIPTION
This PR is fixing #467 where provided jsfddle for demo and steps.

This issue is happening when:
1. there are some number of items on timeline
1. every item is occupying decent time slot
1. items are following each to other
1. zoom is set in the way to see only part of single item (saying item takes 6hrs but timeline displays only 2 hrs range)

Once above conditions are satisfied `binarySearchCustom()` function call which is using to determine `initialPosByEnd` value in  Group._updateItemsInRange() function can return inappropriate value: it can indicate position of item which is pretty far from currently displayed range.

So I have fixed `initialPosByEnd` value comparator function to find out the closest item to current range.

Build and tests are passed locally.

