### PR TITLE
Fix "Graph2d#addCustomTime doesn't work" (#472)

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -411,7 +411,7 @@ class Core {
         'width', 'height', 'minHeight', 'maxHeight', 'autoResize',
         'start', 'end', 'clickToUse', 'dataAttributes', 'hiddenDates',
         'locale', 'locales', 'moment', 'preferZoom', 'rtl', 'zoomKey',
-        'horizontalScroll', 'verticalScroll', 'longSelectPressTime'
+        'horizontalScroll', 'verticalScroll', 'longSelectPressTime', 'snap'
       ];
       util.selectiveExtend(fields, this.options, options);
       this.dom.rollingModeBtn.style.visibility = 'hidden';

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -668,9 +668,9 @@ class Core {
     }
 
     const customTime = new CustomTime(this.body, util.extend({}, this.options, {
-      time : timestamp,
+      time: timestamp,
       id,
-      snap: this.options.snap
+      snap: this.itemSet ? this.itemSet.options.snap : this.options.snap
     }));
 
     this.customTimes.push(customTime);

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -670,7 +670,7 @@ class Core {
     const customTime = new CustomTime(this.body, util.extend({}, this.options, {
       time : timestamp,
       id,
-      snap: this.itemSet.options.snap
+      snap: this.options.snap
     }));
 
     this.customTimes.push(customTime);

--- a/lib/timeline/Graph2d.js
+++ b/lib/timeline/Graph2d.js
@@ -76,6 +76,13 @@ function Graph2d (container, items, groups, options) {
     },
     hiddenDates: [],
     util: {
+      getScale() {
+        return me.timeAxis.step.scale;
+      },
+      getStep() {
+        return me.timeAxis.step.step;
+      },
+
       toScreen: me._toScreen.bind(me),
       toGlobalScreen: me._toGlobalScreen.bind(me), // this refers to the root.width
       toTime: me._toTime.bind(me),

--- a/lib/timeline/optionsGraph2d.js
+++ b/lib/timeline/optionsGraph2d.js
@@ -159,6 +159,7 @@ let allOptions = {
   showMajorLabels: {'boolean': bool},
   showMinorLabels: {'boolean': bool},
   showWeekScale: {'boolean': bool},
+  snap: {'function': 'function', 'null': 'null'},
   start: {date, number, string, moment},
   timeAxis: {
     scale: {string,'undefined': 'undefined'},


### PR DESCRIPTION
Close #472 

The Timeline has the `itemSet` property  but Graph2d doesn't, so the access to `itemSet.options` causes the error. 

demo: https://jsfiddle.net/1u8e4gpc/
