### PR TITLE
Add zoomFriction to option interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -309,6 +309,7 @@ export interface TimelineOptions {
   width?: HeightWidthType;
   zoomable?: boolean;
   zoomKey?: TimelineOptionsZoomKey;
+  zoomFriction?: number;
   zoomMax?: number;
   zoomMin?: number;
 }


### PR DESCRIPTION
The interface `TimelineOptions` of `vis-timeline` is missing the `zoomFriction` option found in the [docs](https://visjs.github.io/vis-timeline/docs/timeline/#Configuration_Options).