### PR TITLE
docs(examples): fix peer build URLs

### DIFF
--- a/examples/timeline/peer-build.html
+++ b/examples/timeline/peer-build.html
@@ -13,7 +13,7 @@
     ></script>
     <script
       type="text/javascript"
-      src="https://unpkg.com/vis-data@latest"
+      src="https://unpkg.com/vis-data@latest/peer/umd/vis-data.min.js"
     ></script>
     <script
       type="text/javascript"
@@ -65,7 +65,7 @@
   For example vis-data&commat;1.0.0 instead of vis-data&commat;latest.
 --&gt;
 &lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/moment&commat;latest&quot;&gt;&lt;/script&gt;
-&lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-data&commat;latest&quot;&gt;&lt;/script&gt;
+&lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-data&commat;latest/peer/umd/vis-data.min.js&quot;&gt;&lt;/script&gt;
 &lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-timeline&commat;latest/peer/umd/vis-timeline-graph2d.min.js&quot;&gt;&lt;/script&gt;
 &lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;https://unpkg.com/vis-timeline/styles/vis-timeline-graph2d.min.css&quot; /&gt;
 &lt;!-- You may include other packages like Vis Network or Vis Graph3D here. --&gt;
@@ -96,7 +96,7 @@
 
     <h5>Bundled ESM</h5>
     <pre><code>
-import { DataSet } from "vis-data";
+import { DataSet } from "vis-data/peer";
 import { Timeline } from "vis-timeline/peer";
 import "vis-timeline/styles/vis-timeline-graph2d.css";
 // You may import from other packages like Vis Network or Vis Graph3D here.


### PR DESCRIPTION
The builds have to match in order to make everything work. The version before combined legacy Vis Data with peer Vis Timeline which doesn't really work.

Closes #510.