### PR TITLE
chore: expose ClusterItem in timeline export

### DIFF
--- a/lib/bundle-legacy.js
+++ b/lib/bundle-legacy.js
@@ -42,6 +42,7 @@ import TimeStep from "./timeline/TimeStep";
 import Item from "./timeline/component/item/Item";
 import BackgroundItem from "./timeline/component/item/BackgroundItem";
 import BoxItem from "./timeline/component/item/BoxItem";
+import ClusterItem from "./timeline/component/item/ClusterItem";
 import PointItem from "./timeline/component/item/PointItem";
 import RangeItem from "./timeline/component/item/RangeItem";
 
@@ -78,6 +79,7 @@ const timeline = {
       Item,
       BackgroundItem,
       BoxItem,
+      ClusterItem,
       PointItem,
       RangeItem
     },

--- a/lib/entry-esnext.js
+++ b/lib/entry-esnext.js
@@ -13,6 +13,7 @@ import TimeStep from "./timeline/TimeStep";
 import Item from "./timeline/component/item/Item";
 import BackgroundItem from "./timeline/component/item/BackgroundItem";
 import BoxItem from "./timeline/component/item/BoxItem";
+import ClusterItem from "./timeline/component/item/ClusterItem";
 import PointItem from "./timeline/component/item/PointItem";
 import RangeItem from "./timeline/component/item/RangeItem";
 
@@ -48,6 +49,7 @@ const timeline = {
       Item,
       BackgroundItem,
       BoxItem,
+      ClusterItem,
       PointItem,
       RangeItem
     },

--- a/lib/entry-standalone.js
+++ b/lib/entry-standalone.js
@@ -29,6 +29,7 @@ import TimeStep from "./timeline/TimeStep";
 import Item from "./timeline/component/item/Item";
 import BackgroundItem from "./timeline/component/item/BackgroundItem";
 import BoxItem from "./timeline/component/item/BoxItem";
+import ClusterItem from "./timeline/component/item/ClusterItem";
 import PointItem from "./timeline/component/item/PointItem";
 import RangeItem from "./timeline/component/item/RangeItem";
 
@@ -67,6 +68,7 @@ const timeline = {
       Item,
       BackgroundItem,
       BoxItem,
+      ClusterItem,
       PointItem,
       RangeItem
     },


### PR DESCRIPTION
This pull request exposes ClusterItem in the timeline.items export, alongside the existing exports of BoxItem, PointItem, etc