### PR TITLE
fix: update lastStart on every graph update

### DIFF
--- a/lib/timeline/component/LineGraph.js
+++ b/lib/timeline/component/LineGraph.js
@@ -109,7 +109,6 @@ function LineGraph(body, options) {
   this.setOptions(options);
   this.groupsUsingDefaultStyles = [0];
   this.body.emitter.on('rangechanged', function () {
-    me.lastStart = me.body.range.start;
     me.svg.style.left = util.option.asSize(-me.props.width);
 
     me.forceGraphUpdate = true;
@@ -637,6 +636,7 @@ LineGraph.prototype._getSortedGroupIds = function(){
  * @private
  */
 LineGraph.prototype._updateGraph = function () {
+  this.lastStart = this.body.range.start;
   // reset the svg elements
   DOMutil.prepareElements(this.svgElements);
   if (this.props.width != 0 && this.itemsData != null) {


### PR DESCRIPTION
Normally dragging a line graph (or calling setRange repeatedly to sync
the range with something external) causes only partial updates (the SVG
is moved as a whole, not modified). However, if at the same time full
updates happen the graph can become moved twice: once because the items
have been moved and the second time due to the SVG offset.

To avoid this problem update the lastStart reference
position not only when the drag ends, but also on any other full graph
rebuild.