### PR TITLE
fix: reset SVG position on full graph update

### DIFF
--- a/lib/timeline/component/LineGraph.js
+++ b/lib/timeline/component/LineGraph.js
@@ -585,6 +585,8 @@ LineGraph.prototype.redraw = function () {
   if (resized == true || zoomed == true || this.abortedGraphUpdate == true || this.forceGraphUpdate == true) {
     resized = this._updateGraph() || resized;
     this.forceGraphUpdate = false;
+    this.lastStart = this.body.range.start;
+    this.svg.style.left = (-this.props.width) + 'px';
   }
   else {
     // move the whole svg while dragging
@@ -636,7 +638,6 @@ LineGraph.prototype._getSortedGroupIds = function(){
  * @private
  */
 LineGraph.prototype._updateGraph = function () {
-  this.lastStart = this.body.range.start;
   // reset the svg elements
   DOMutil.prepareElements(this.svgElements);
   if (this.props.width != 0 && this.itemsData != null) {


### PR DESCRIPTION
This is a follow-up to visjs/vis-timeline#651 (sorry, I failed to do it correctly the first time). If redraw causes a full update, the SVG position needs to be reset too because the lastStart to position propagation does not happen in this branch.