### PR TITLE
Fix markdown links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ import { Timeline } from "vis-timeline/standalone";
 
 This has no dependencies and therefore is great for things like MWEs but has
 more issues with interoperability and bundle bloat. For more information see the
-following (example)[https://visjs.github.io/vis-timeline/examples/timeline/standalone-build.html].
+following [example](https://visjs.github.io/vis-timeline/examples/timeline/standalone-build.html).
 
 ### Peer build
 
@@ -101,7 +101,7 @@ import { Timeline } from "vis-timeline/peer";
 For this build to work you have to load Vis Data and Moment (including locales
 except English) packages yourself. The advantage here is that it works well with
 other packages. For more information see the following
-(example)[https://visjs.github.io/vis-timeline/examples/timeline/peer-build.html].
+[example](https://visjs.github.io/vis-timeline/examples/timeline/peer-build.html).
 
 ### ESNext build
 


### PR DESCRIPTION
According to [GFM 6.6 Links](https://github.github.com/gfm/#links) the format is `[text](link)`.