### PR TITLE
fix: format options object so its unique within a TimeAxis instance

### DIFF
--- a/lib/timeline/component/TimeAxis.js
+++ b/lib/timeline/component/TimeAxis.js
@@ -45,7 +45,7 @@ class TimeAxis extends Component {
       showMajorLabels: true,
       showWeekScale: false,
       maxMinorChars: 7,
-      format: TimeStep.FORMAT,
+      format: util.extend({}, TimeStep.FORMAT),
       moment,
       timeAxis: null
     };


### PR DESCRIPTION
Found multiple instances of a timeline were sharing formats. This is due to the TimeStep.FORMAT being directly referenced by each defaultOptions created within a TimeAxis.