### PR TITLE
fix: add template functions can return HTMLElement

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -227,7 +227,7 @@ export type TimelineOptionsMarginType = number | TimelineMarginOption;
 export type TimelineOptionsOrientationType = string | TimelineOrientationOption;
 export type TimelineOptionsSnapFunction = (date: Date, scale: string, step: number) => Date | number;
 export type TimelineOptionsSnapType = null | TimelineOptionsSnapFunction;
-export type TimelineOptionsTemplateFunction = (item?: any, element?: any, data?: any) => string;
+export type TimelineOptionsTemplateFunction = (item?: any, element?: any, data?: any) => string | HTMLElement;
 export type TimelineOptionsComparisonFunction = (a: any, b: any) => number;
 export type TimelineOptionsGroupHeightModeType = 'auto' | 'fixed' | 'fitItems';
 export type TimelineOptionsClusterCriteriaFunction = (firstItem: TimelineItem, secondItem: TimelineItem) => boolean;


### PR DESCRIPTION
In my own use case, I'm trying to attach a Vue component containing an image. Some properties are computed against `scrollHeight` of this image, and this is 0 if the element is not attached to the DOM.

So returning `outerHTML` is not the same thing as returning the element itself.

**Thank you for contributing to vis.js!!**

Please make sure to check the following requirements before creating a pull request:

* [x] All pull requests must be to the [master branch](https://github.com/visjs/vis-timeline/tree/master).
* [ ] Provide an additional or update an example to demonstrate your changes or new features.
* [ ] Make sure your changes are based on the latest version of the [master branch](https://github.com/visjs/vis-timeline/tree/master). (Use e.g. `git fetch && git rebase origin master` to update your feature branch).
* [ ] Update the documentation if you introduced new behavior or changed existing behavior.
* [ ] Reference issue numbers of issues that your pull request addresses. (If you write something like `fixes #1781` in your git commit message this issue gets closed automatically by merging your pull request).
* [ ] Expect review comments and change requests by reviewer.
* [ ] Delete this checklist from your pull request.
