### PR TITLE
fix(deps): add XSS among peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "propagating-hammerjs": "^1.4.0 || ^2.0.0",
     "uuid": "^3.4.0 || ^7.0.0",
     "vis-data": "^6.3.0 || ^7.0.0",
-    "vis-util": "^3.0.0 || ^4.0.0"
+    "vis-util": "^3.0.0 || ^4.0.0",
+    "xss": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.12.10",

--- a/rollup.build.js
+++ b/rollup.build.js
@@ -11,7 +11,8 @@ export default generateRollupConfiguration({
     "vis-util": "vis",
     keycharm: "keycharm",
     moment: "moment",
-    uuid: "uuid"
+    uuid: "uuid",
+    xss: "filterXSS",
   },
   header: { name: "vis-timeline and vis-graph2d" },
   libraryFilename: "vis-timeline-graph2d",


### PR DESCRIPTION
As stated in https://github.com/visjs/vis-timeline/pull/840#issuecomment-748640374, XSS should be listed among other dependencies as it is needed during runtime.