### PR TITLE
fix(graph2d): graph2d.setItems doesn't work sometimes

### DIFF
--- a/lib/timeline/Graph2d.js
+++ b/lib/timeline/Graph2d.js
@@ -198,7 +198,7 @@ Graph2d.prototype.setItems = function(items) {
   if (!items) {
     newDataSet = null;
   }
-  else if (isDataViewLike("id", newDataSet)) {
+  else if (isDataViewLike("id", items)) {
     newDataSet = typeCoerceDataSet(items);
   }
   else {


### PR DESCRIPTION
fixes #981

`graph2d.setItems` checked `newDataSet`(it is null!) as DataViewLike, so I fixed to replace `newDataSet` to `items`.

codepen: https://codepen.io/youku_s/pen/YzNwRzP