### PR TITLE
fix: allow configuring the XSS protection behavior

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -296,9 +296,9 @@ var items = new vis.DataSet([
       <td>selectable</td>
       <td>Boolean</td>
       <td>no</td>
-      <td>Ability to enable/disable selectability for specific items. 
+      <td>Ability to enable/disable selectability for specific items.
           Defaults to <code>true</code>. Does not override the timeline's
-          <code>selectable</code> configuration option. 
+          <code>selectable</code> configuration option.
       </td>
     </tr>
     <tr>
@@ -466,7 +466,7 @@ var groups = [
       <td>subgroupStack</td>
       <td>Object or Boolean</td>
       <td>none</td>
-      <td>Enables stacking within individual subgroups. Example: <code>{'subgroup0': true, 'subgroup1': false, 'subgroup2': true}</code> 
+      <td>Enables stacking within individual subgroups. Example: <code>{'subgroup0': true, 'subgroup1': false, 'subgroup2': true}</code>
           For each subgroup where stacking is enabled, items will be stacked on top of each other within that subgroup such that they do no overlap.
           If set to <code>true</code> all subgroups will be stacked.
           If a value was specified for the <code>order</code> parameter in the options, that ordering will be used when stacking the items.
@@ -476,8 +476,8 @@ var groups = [
       <td>subgroupVisibility</td>
       <td>Object</td>
       <td>none</td>
-      <td>Ability to hide/show specific subgroups. Example: <code>{'hiddenSubgroup0': false, 'subgroup1': true, 'subgroup2': true}</code> 
-          If a subgroup is missing from the object, it will default as true (visible). 
+      <td>Ability to hide/show specific subgroups. Example: <code>{'hiddenSubgroup0': false, 'subgroup1': true, 'subgroup2': true}</code>
+          If a subgroup is missing from the object, it will default as true (visible).
       </td>
     </tr>
     <tr>
@@ -933,7 +933,7 @@ function (option, path) {
       <td>Callback function triggered when an item is about to be added: when the user double taps an empty space in the Timeline. See section <a href="#Editing_Items">Editing Items</a> for more information. Only applicable when both options <code>selectable</code> and <code>editable.add</code> are set <code>true</code>.
       </td>
     </tr>
-    
+
     <tr>
       <td>onAddGroup</td>
       <td>function</td>
@@ -941,7 +941,7 @@ function (option, path) {
       <td>Callback function triggered when a group is about to be added. The signature and semantics are the same as for <code>onAdd</code>.
       </td>
     </tr>
-    
+
     <tr>
         <td>onDropObjectOnItem</td>
         <td>function</td>
@@ -957,7 +957,7 @@ function (option, path) {
       <td>Callback function triggered when the timeline is initially drawn. This function fires once per timeline creation.
       </td>
     </tr>
-    
+
     <tr>
       <td>onMove</td>
       <td>function</td>
@@ -965,7 +965,7 @@ function (option, path) {
       <td>Callback function triggered when an item has been moved: after the user has dragged the item to an other position. See section <a href="#Editing_Items">Editing Items</a> for more information. Only applicable when both options <code>selectable</code> and <code>editable.updateTime</code> or <code>editable.updateGroup</code> are set <code>true</code>.
       </td>
     </tr>
-    
+
     <tr>
       <td>onMoveGroup</td>
       <td>function</td>
@@ -973,7 +973,7 @@ function (option, path) {
       <td>Callback function triggered when a group has been moved: after the user has dragged the group to an other position. The signature and semantics are the same as for <code>onMove</code>.
       </td>
     </tr>
-    
+
     <tr>
       <td>onMoving</td>
       <td>function</td>
@@ -981,7 +981,7 @@ function (option, path) {
       <td>Callback function triggered repeatedly when an item is being moved. See section <a href="#Editing_Items">Editing Items</a> for more information. Only applicable when both options <code>selectable</code> and <code>editable.updateTime</code> or <code>editable.updateGroup</code> are set <code>true</code>.
       </td>
     </tr>
-    
+
     <tr>
       <td>onRemove</td>
       <td>function</td>
@@ -989,7 +989,7 @@ function (option, path) {
       <td>Callback function triggered when an item is about to be removed: when the user tapped the delete button on the top right of a selected item. See section <a href="#Editing_Items">Editing Items</a> for more information. Only applicable when both options <code>selectable</code> and <code>editable.remove</code> are set <code>true</code>.
       </td>
     </tr>
-    
+
     <tr>
       <td>onRemoveGroup</td>
       <td>function</td>
@@ -997,7 +997,7 @@ function (option, path) {
       <td>Callback function triggered when a group is about to be removed. The signature and semantics are the same as for <code>onRemove</code>.
       </td>
     </tr>
-    
+
     <tr>
       <td>onUpdate</td>
       <td>function</td>
@@ -1005,7 +1005,7 @@ function (option, path) {
       <td>Callback function triggered when an item is about to be updated, when the user double taps an item in the Timeline. See section <a href="#Editing_Items">Editing Items</a> for more information. Only applicable when both options <code>selectable</code> and <code>editable.updateTime</code> or <code>editable.updateGroup</code> are set <code>true</code>.
       </td>
     </tr>
-    
+
     <tr>
       <td>order</td>
       <td>function</td>
@@ -1336,6 +1336,31 @@ function (option, path) {
       <td>The width of the timeline in pixels or as a percentage.</td>
     </tr>
 
+    <tr class='toggle collapsible' onclick="toggleTable('optionTable','xss', this);">
+      <td><span parent="xss" class="right-caret"></span> xss</td>
+      <td>Object</td>
+      <td>none</td>
+      <td>Configure the XSS protection behavior of Timeline, which is always enabled by default. This means that most attributes and HTML elements are either removed or escaped before output.</td>
+    </tr>
+    <tr parent="xss" class="hidden">
+      <td class="indent">xss.disabled</td>
+      <td>Boolean</td>
+      <td>undefined</td>
+      <td>Explicitly set this option to <code>true</code> to completely disable Timeline's XSS protection.
+        <p>Note: Please make sure you install protection against XSS vulnerabilities yourself!</p>
+      </td>
+    </tr>
+
+    <tr parent="xss" class="hidden">
+      <td class="indent">xss.filterOptions</td>
+      <td>XSS.IFilterXSSOptions</td>
+      <td>undefined</td>
+      <td>This allows to customize whitelisting of HTMLElements, attributes and different handler functions. For more details, please refer to
+        <a href="https://github.com/leizongmin/js-xss#custom-filter-rules" target="_blank" rel="noopener noreferer">the documentation of js-xss</a> and
+        <a href="https://github.com/leizongmin/js-xss/blob/master/typings/xss.d.ts#L12" target="_blank" rel="noopener noreferer">the related typings</a>.
+      </td>
+    </tr>
+
     <tr>
       <td>zoomable</td>
       <td>boolean</td>
@@ -1640,7 +1665,7 @@ document.getElementById('myTimeline').onclick = function (event) {
         <ul>
           <li><code>animation: boolean or {duration: number, easingFunction: string}</code><br>If true (default) or an Object, the range is animated smoothly to the new window. An object can be provided to specify duration and easing function. Default duration is 500 ms, and default easing function is <code>'easeInOutQuad'</code>. Available easing functions: <code>"linear"</code>, <code>"easeInQuad"</code>, <code>"easeOutQuad"</code>, <code>"easeInOutQuad"</code>, <code>"easeInCubic"</code>, <code>"easeOutCubic"</code>, <code>"easeInOutCubic"</code>, <code>"easeInQuart"</code>, <code>"easeOutQuart"</code>, <code>"easeInOutQuart"</code>, <code>"easeInQuint"</code>, <code>"easeOutQuint"</code>, <code>"easeInOutQuint"</code>.</li>
         </ul>
-        A callback <code>function</code> can be passed as an optional parameter. This function will be called at the end of setWindow function. 
+        A callback <code>function</code> can be passed as an optional parameter. This function will be called at the end of setWindow function.
       </td>
     </tr>
 

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -60,6 +60,7 @@ export default class Timeline extends Core {
       moment,
     };
     this.options = util.deepExtend({}, this.defaultOptions);
+    options && util.setupXSSProtection(options.xss);
 
     // Create the DOM, props, and emitter
     this._create(container);
@@ -211,7 +212,7 @@ export default class Timeline extends Core {
         }
       }
 
-      if (!me.initialDrawDone && (me.initialRangeChangeDone || (!me.options.start && !me.options.end) 
+      if (!me.initialDrawDone && (me.initialRangeChangeDone || (!me.options.start && !me.options.end)
         || me.options.rollingMode)) {
         me.initialDrawDone = true;
         me.itemSet.initialDrawDone = true;
@@ -310,7 +311,7 @@ export default class Timeline extends Core {
    */
   setItems(items) {
     this.itemsDone = false;
-    
+
     // convert to type DataSet when needed
     let newDataSet;
     if (!items) {
@@ -341,14 +342,14 @@ export default class Timeline extends Core {
     // convert to type DataSet when needed
     let newDataSet;
     const filter = group => group.visible !== false;
-    
+
     if (!groups) {
       newDataSet = null;
     }
     else {
       // If groups is array, turn to DataSet & build dataview from that
       if (Array.isArray(groups)) groups = new DataSet(groups);
-      
+
       newDataSet = new DataView(groups,{filter});
     }
 
@@ -483,7 +484,7 @@ export default class Timeline extends Core {
           // The redraw shifted elements, so reset the animation to correct
           initialVerticalScroll = verticalScroll;
           startPos = me._getScrollTop() * -1;
-        }      
+        }
 
         const from = startPos;
         const to = initialVerticalScroll.scrollOffset;
@@ -512,7 +513,7 @@ export default class Timeline extends Core {
         // Double check we ended at the proper scroll position
         setFinalVerticalPosition();
 
-        // Let the redraw settle and finalize the position.      
+        // Let the redraw settle and finalize the position.
         setTimeout(setFinalVerticalPosition, 100);
       };
 
@@ -528,7 +529,7 @@ export default class Timeline extends Core {
         initialVerticalScroll = { shouldScroll: false, scrollOffset: -1, itemTop: -1 };
       }
 
-      this.range.setRange(middle - interval / 2, middle + interval / 2, { animation }, finalVerticalCallback, verticalAnimationFrame);  
+      this.range.setRange(middle - interval / 2, middle + interval / 2, { animation }, finalVerticalCallback, verticalAnimationFrame);
     }
   }
 
@@ -689,7 +690,7 @@ export default class Timeline extends Core {
     const centerContainerRect = this.dom.centerContainer.getBoundingClientRect();
     const x = this.options.rtl ? centerContainerRect.right - clientX : clientX - centerContainerRect.left;
     const y = clientY - centerContainerRect.top;
-    
+
     const item  = this.itemSet.itemFromTarget(event);
     const group = this.itemSet.groupFromTarget(event);
     const customTime = CustomTime.customTimeFromTarget(event);
@@ -800,12 +801,12 @@ function getItemVerticalScroll(timeline, item) {
 
   const itemsetHeight = timeline.options.rtl ? timeline.props.rightContainer.height : timeline.props.leftContainer.height;
   const contentHeight = timeline.props.center.height;
-  
+
   const group = item.parent;
   let offset = group.top;
   let shouldScroll = true;
   const orientation = timeline.timeAxis.options.orientation.axis;
-  
+
   const itemTop = () => {
   if (orientation == "bottom") {
       return group.height - item.top - item.height;

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -149,7 +149,7 @@ let allOptions = {
   showWeekScale: { 'boolean': bool},
   stack: { 'boolean': bool},
   stackSubgroups: { 'boolean': bool},
-  cluster: { 
+  cluster: {
     maxItems: {'number': number, 'undefined': 'undefined'},
     titleTemplate: {'string': string, 'undefined': 'undefined'},
     clusterCriteria: { 'function': 'function', 'undefined': 'undefined'},
@@ -188,7 +188,14 @@ let allOptions = {
   zoomFriction: {number},
   zoomMax: {number},
   zoomMin: {number},
-
+  xss: {
+    disabled: { boolean: bool },
+    filterOptions: {
+      __any__: { any },
+      __type__: { object }
+    },
+    __type__: { object }
+  },
   __type__: {object}
 };
 
@@ -290,7 +297,8 @@ let configureOptions = {
     zoomable: true,
     zoomKey: ['ctrlKey', 'altKey', 'shiftKey', 'metaKey', ''],
     zoomMax: [315360000000000, 10, 315360000000000, 1],
-    zoomMin: [10, 10, 315360000000000, 1]
+    zoomMin: [10, 10, 315360000000000, 1],
+    xss: { disabled: false }
   }
 };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,7 +6,7 @@ import { getType, isNumber, isString } from "vis-util/esnext";
 import { DataSet, createNewDataPipeFrom } from "vis-data/esnext";
 
 import moment from "moment";
-import xss  from 'xss';
+import xssFilter from 'xss';
 
 // parse ASP.Net Date pattern,
 // for example '/Date(1198908717056)/' or '/Date(1198908717056-0700)/'
@@ -87,13 +87,13 @@ export function convert(object, type) {
         if (match) {
           // object is an ASP date
           return moment(Number(match[1])); // parse number
-        } 
+        }
         match = NumericRegex.exec(object);
 
         if (match) {
           return moment(Number(object));
         }
-        
+
         return moment(object); // parse string
       } else {
         throw new TypeError(
@@ -225,8 +225,46 @@ export function typeCoerceDataSet(
   };
 }
 
-export default {
+// Configure XSS protection
+const setupXSSCleaner = (options) => {
+  const customXSS = new xssFilter.FilterXSS(options);
+  return (string) => customXSS.process(string);
+};
+const setupNoOpCleaner = (string) => string;
+
+// when nothing else is configured: filter XSS with the lib's default options
+let configuredXSSProtection = setupXSSCleaner();
+
+const setupXSSProtection = (options) => {
+  // No options? Do nothing.
+  if (!options) {
+    return;
+  }
+
+  // Disable XSS protection completely on request
+  if (options.disabled === true) {
+    configuredXSSProtection = setupNoOpCleaner;
+    console.warn('You disabled XSS protection for vis-Timeline. I sure hope you know what you\'re doing!');
+  } else {
+    // Configure XSS protection with some custom options.
+    // For a list of valid options check the lib's documentation:
+    // https://github.com/leizongmin/js-xss#custom-filter-rules
+    if (options.filterOptions) {
+      configuredXSSProtection = setupXSSCleaner(options.filterOptions);
+    }
+  }
+};
+
+const availableUtils = {
   ...util,
   convert,
-  xss
+  setupXSSProtection
 };
+
+Object.defineProperty(availableUtils, 'xss', {
+  get: function() {
+    return configuredXSSProtection;
+  }
+})
+
+export default availableUtils;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -212,6 +212,11 @@ export interface TimelineTooltipOption {
   template?: (item: TimelineItem, editedData?: TimelineItem) => string;
 }
 
+export interface TimelineXSSProtectionOption {
+  disabled: boolean;
+  filterOptions?: XSS.IFilterXSSOptions;
+}
+
 export type TimelineOptionsConfigureFunction = (option: string, path: string[]) => boolean;
 export type TimelineOptionsConfigureType = boolean | TimelineOptionsConfigureFunction;
 export type TimelineOptionsDataAttributesType = boolean | string | string[];
@@ -312,6 +317,7 @@ export interface TimelineOptions {
   zoomFriction?: number;
   zoomMax?: number;
   zoomMin?: number;
+  xss?: TimelineXSSProtectionOption;
 }
 
 /**


### PR DESCRIPTION
I tried different ways on how to implement this and thought about the ideas previously discussed in the issue #846.
After some fiddling around I decided to keep things quite simple here, to get this off and rolling for everyone.

The basic concept includes the following:
- keep util.xss() usages unchanged
- allow to disable xss protection completely
- allow to control xss library's behavior using its public interfaces

Note: This still means, that the current default behavior will remain unchanged, but users will be able to gain control over it and have alternative options. See below.


To achieve things I basically did the following: 
1. replaced the xss export in util.js with a dynamic getter using Object.defineProperty, because this allows to exchange the XSS protection algorithms behind it, while keeping that an internal detail

2. add configuration options to Timeline, which allow to: 
a) disable XSS protection completely and 
b) optionally also change the xss library's behavior using its XSS.IFilterXSSOptions

3. hand these configuration options to a setup function at instanciation time, to define how that particular Timeline instance will behave with regards to XSS filtering

4. if someone disabled the xss protection, that makes Timelien log a warning, because... the protection is in for good reason, so why should you disable it completely (other than you know what you are doing)!?

The "disabled" must be set explictly, otherwise the xss protection will remain in place.
The protection also defaults to the current state, using the xss filter with no option at all.

This solution might not be perfect, because the dynamic getter could impact performance; also this solution does not account for treating XSS differently for loading screen, item contents, groups etc.

However I think this is at least a good intermediate solution. This might also be worth shipping, because it is a relief for both: us and the people out there, as they now have the option to get control over the XSS protection.



Here's the examples I used to verify its behavior:

With Options set to:

```js
  ...
  xss: {
    disabled: false,
    filterOptions: {
      whiteList: { p: ['class', 'data-from-template'], div: 'class' },
    },
  },
```

CASE 1:

```js
  template: function (item, element, data) {
    return `<div class="not-xss-filtered-html" data-from-template="yes">${item.content}</div>`;
  }
```

output keeps the element, but only the class attribute passes through:

```html
<div class="not-xss-filtered-html">This is the item.content</div>
```

CASE 2:

```js
  template: function (item, element, data) {
    return `<p class="not-xss-filtered-html" data-from-template="yes">${item.content}</p>`;
  }
```

output keeps element and both attributes:

```html
<p class="not-xss-filtered-html" data-from-template="yes">This is the item.content</p>
```

CASE 3:

```js
  template: function (item, element, data) {
    return `<span class="not-xss-filtered-html" data-from-template="yes">${item.content}</span>`;
  }
```

output is esacped, because span is no valid element:

```html
&lt;span class="not-xss-filtered-html" data-from-template="yes"&gt;This is the item.content&lt;/span&gt;
```


With Options set to:

```js
  ...
  xss: {
    disabled: true,
  },
```

The startup of Timeline produces a console warning:

`You disabled XSS protection for vis-Timeline. I sure hope you know what you're doing!`