### PR TITLE
Automatic vertical scrolling when dragging items

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1770,6 +1770,41 @@ class ItemSet extends Component {
             newOffset = Math.min(me.groupIds.length-1, newOffset);
             itemData.group = me.groupIds[newOffset];
           }
+
+          // find the vertical scroll div
+          const scrollDiv = document.querySelector('div .vis-vertical-scroll');
+          if (scrollDiv) {
+            // clear auto scroll interval
+            clearInterval(this.autoScrollInterval);
+
+            const reachedMinScroll = 0 === scrollDiv.scrollTop;
+            const reachedMaxScroll = scrollDiv.scrollTop >= (scrollDiv.scrollHeight - scrollDiv.offsetHeight);
+        
+            // get the bounding rectangle of the div
+            const scrollRect = scrollDiv.getBoundingClientRect();
+          
+            // determine distances from top and bottom
+            const relativeTop = event.center.y - scrollRect.top;
+            const relativeBottom = relativeTop - scrollDiv.offsetHeight;
+
+            if (relativeTop < 15 && !reachedMinScroll) {
+              // set auto scroll intervall
+              this.autoScrollInterval = setInterval(() => {
+                // scrolling upwards
+                if (0 !== scrollDiv.scrollTop) {
+                  scrollDiv.scrollTop = scrollDiv.scrollTop - 20;
+                }
+              }, 100);
+            } else if (relativeBottom > -15 && !reachedMaxScroll) {
+              // set auto scroll intervall
+              this.autoScrollInterval = setInterval(() => {
+                // scrolling downwards
+                if (scrollDiv.scrollTop < (scrollDiv.scrollHeight - scrollDiv.offsetHeight)) {
+                  scrollDiv.scrollTop = scrollDiv.scrollTop + 20;
+                }
+              }, 100);
+            }
+          }
         }
 
         // confirm moving the item
@@ -1812,6 +1847,8 @@ class ItemSet extends Component {
    */
   _onDragEnd(event) {
     this.touchParams.itemIsDragging = false;
+    clearInterval(this.autoScrollInterval);
+    
     if (this.touchParams.itemProps) {
       event.stopPropagation();
 


### PR DESCRIPTION
If there are more groups than the screen can display without scrolling, it's impossible to move an Item to a group outside the visible reactangle in one drag.
So I added automatic vertical scrolling when dragging an Item to the bottom (or top).

The aspect that I find the scrollable div via querySelector is a bit dirty. But it works for me.