### PR TITLE
fix: reference to IFilterXSSOptions

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1353,7 +1353,7 @@ function (option, path) {
 
     <tr parent="xss" class="hidden">
       <td class="indent">xss.filterOptions</td>
-      <td>XSS.IFilterXSSOptions</td>
+      <td>IFilterXSSOptions</td>
       <td>undefined</td>
       <td>This allows to customize whitelisting of HTMLElements, attributes and different handler functions. For more details, please refer to
         <a href="https://github.com/leizongmin/js-xss#custom-filter-rules" target="_blank" rel="noopener noreferer">the documentation of js-xss</a> and

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,6 +25,7 @@ export type DataViewDataGroup = DataView<DataGroup, 'id'>;
 export type DataViewDataItem = DataView<DataItem, 'id'>;
 
 import { MomentInput, MomentFormatSpecification, Moment } from 'moment';
+import { IFilterXSSOptions } from 'xss';
 export type MomentConstructor1 =
   (inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean) => Moment;
 export type MomentConstructor2 =
@@ -214,7 +215,7 @@ export interface TimelineTooltipOption {
 
 export interface TimelineXSSProtectionOption {
   disabled: boolean;
-  filterOptions?: XSS.IFilterXSSOptions;
+  filterOptions?: IFilterXSSOptions;
 }
 
 export type TimelineOptionsConfigureFunction = (option: string, path: string[]) => boolean;


### PR DESCRIPTION
Fixes the reference for the filter options configuration to use the interface exported by js-xss directly, leaving the namespace out. This should then fix the typescript errors in #1015 