### PR TITLE
fix: Update TimelineEventPropertiesResult typing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -383,6 +383,11 @@ export interface TimelineEventPropertiesResult {
    * The original click event.
    */
   event: Event;
+
+  /**
+   * If the event is clustered.
+   */
+  isCluster: boolean;
 }
 
 export type DataItemCollectionType = DataItem[] | DataInterfaceDataItem;


### PR DESCRIPTION
This pull request adds 'isCluster' to the TimelineEventPropertiesResult. It exists in JS, but doesn't have the typing in TS.   getEventProperties(event) in Timeline.js returns a boolean for 'isCluster'.