### PR TITLE
Fix urls in the readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ of the project.
 <html>
 <head>
   <title>Timeline</title>
-  <script type="text/javascript" src="//unpkg.com/vis-timeline@latest/standalone/umd/vis-timeline-graph2d.min.js"></script>
-  <link href="//unpkg.com/vis-timeline@latest/styles/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="https://unpkg.com/vis-timeline@latest/standalone/umd/vis-timeline-graph2d.min.js"></script>
+  <link href="https://unpkg.com/vis-timeline@latest/styles/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
   <style type="text/css">
     #visualization {
       width: 600px;


### PR DESCRIPTION
Add missing `https:` in the urls in the README's example. The current code doesn't work since the URLs don't resolve.