### PR TITLE
fix: wrong instance member name.

### DIFF
--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -213,7 +213,7 @@ class Item {
       this.hammerDragCenter.on('panmove',  me.parent.itemSet._onDrag.bind(me.parent.itemSet));
       this.hammerDragCenter.on('panend',   me.parent.itemSet._onDragEnd.bind(me.parent.itemSet));
       // delay addition on item click for trackpads...
-      this.hammer.get('press').set({time:10000});
+      this.hammerDragCenter.get('press').set({time:10000});
 
       if (this.dom.box) {
         if (this.dom.dragLeft) {


### PR DESCRIPTION
Symptom before fix: an item cannot be moved (item time update by drag and drop).

Error logged in browser console:
Uncaught TypeError: this.hammer is undefined
