### PR TITLE
feat: Improve performance of stack function

### DIFF
--- a/lib/timeline/Stack.js
+++ b/lib/timeline/Stack.js
@@ -38,16 +38,13 @@ export function orderByEnd(items) {
  * @return {boolean} shouldBail
  */
 export function stack(items, margin, force, shouldBailItemsRedrawFunction) {
-  const rtl = !!(items[0] && items[0].options.rtl);
-  items.sort((a, b) => compareSpatially(a, b) * (rtl ? -1 : 1));
   const stackingResult = performStacking(
     items,
     margin.item,
+    false,
     item => item.stack && (force || item.top === null),
     item => item.stack,
     item => margin.axis,
-    (a, b) => checkHorizontalSpatialCollision(a, b, margin.item, b.options.rtl),
-    (a, b) => checkVerticalSpatialCollision(a, b, margin.item),
     shouldBailItemsRedrawFunction
   );
 
@@ -66,16 +63,13 @@ export function stack(items, margin, force, shouldBailItemsRedrawFunction) {
  *            The subgroup that is being stacked
  */
 export function substack(items, margin, subgroup) {
-  const rtl = !!(items[0] && items[0].options.rtl);
-  items.sort((a, b) => compareSpatially(a, b) * (rtl ? -1 : 1));
   const subgroupHeight = performStacking(
     items,
     margin.item,
+    false,
     item => item.stack,
     item => true,
-    item => item.baseTop,
-    (a, b) => checkHorizontalSpatialCollision(a, b, margin.item, b.options.rtl),
-    (a, b) => checkVerticalSpatialCollision(a, b, margin.item)
+    item => item.baseTop
   );
   subgroup.height = subgroupHeight - subgroup.top + 0.5 * margin.item.vertical;
 }
@@ -130,12 +124,10 @@ export function stackSubgroups(items, margin, subgroups) {
     {
       vertical: 0
     },
+    true,
     item => true,
     item => true,
-    item => 0,
-    (a, b) => checkHorizontalTimeCollision(a, b),
-    (a, b) => checkVerticalSpatialCollision(a, b, {vertical: 0}),
-    null
+    item => 0
   );
 
   for (let i = 0; i < items.length; i++) {
@@ -207,20 +199,19 @@ export function stackSubgroupsWithInnerStack(subgroupItems, margin, subgroups) {
  * Reusable stacking function
  * 
  * @param {Item[]} items 
- * An array of items to consider during stacking. Must be sorted by start time!
+ * An array of items to consider during stacking.
  * @param {{horizontal: number, vertical: number}} margins
  * Margins to be used for collision checking and placement of items.
+ * @param {boolean} compareTimes
+ * By default, horizontal collision is checked based on the spatial position of the items (left/right and width).
+ * If this argument is true, horizontal collision will instead be checked based on the start/end times of each item.
+ * Vertical collision is always checked spatially.
  * @param {(Item) => number | null} shouldStack
  * A callback function which is called before we start to process an item. The return value indicates whether the item will be processed.
  * @param {(Item) => boolean} shouldOthersStack
  * A callback function which indicates whether other items should consider this item when being stacked.
  * @param {(Item) => number} getInitialHeight
  * A callback function which determines the height items are initially placed at
- * @param {(Item, Item) => boolean} checkHorizontalOverlap
- * A callback function which indicates whether two items overlap horizontally
- * @param {(Item, Item) => boolean | null} checkVerticalOverlap
- * A callback function which indicates whether two items overlap vertically.
- * If null is specified, items will always be placed below any prior items that overlap horizontally.
  * @param {() => boolean} shouldBail 
  * A callback function which should indicate if the stacking process should be aborted.
  * 
@@ -228,80 +219,119 @@ export function stackSubgroupsWithInnerStack(subgroupItems, margin, subgroups) {
  * if shouldBail was triggered, returns null
  * otherwise, returns the maximum height
  */
- function performStacking(items, margins, shouldStack, shouldOthersStack, getInitialHeight, checkHorizontalOverlap, checkVerticalOverlap, shouldBail) {
-  const currentStack = [];
-  let maxHeight = 0;
+function performStacking(items, margins, compareTimes, shouldStack, shouldOthersStack, getInitialHeight, shouldBail) {
+  // Time-based horizontal comparison
+  let getItemStart = item => item.start;
+  let getItemEnd = item => item.end;
+  if(!compareTimes) {
+    // Spatial horizontal comparisons
+    const rtl = !!(items[0] && items[0].options.rtl);
+    if(rtl) {
+      getItemStart = item => item.right;
+    } else {
+      getItemStart = item => item.left;
+    }
+    getItemEnd = item => getItemStart(item) + item.width + margins.horizontal;
+  }
 
-  for (var i = 0; i < items.length; i++) {
-    const item = items[i];
+  const itemsToPosition = [];
+  const itemsAlreadyPositioned = []; // It's vital that this array is kept sorted based on the start of each item
 
+  // If the order we needed to place items was based purely on the start of each item, we could calculate stacking very efficiently.
+  // Unfortunately for us, this is not guaranteed. But the order is often based on the start of items at least to some degree, and
+  // we can use this to make some optimisations. While items are proceeding in order of start, we can keep moving our search indexes
+  // forwards. Then if we encounter an item that's out of order, we reset our indexes and search from the beginning of the array again.
+  let previousStart = null;
+  let insertionIndex = 0;
+
+  // First let's handle any immoveable items
+  for(const item of items) {
     if(shouldStack(item)) {
-      if(shouldBail && shouldBail()) { return null; }
+      itemsToPosition.push(item);
+    } else {
+      if(shouldOthersStack(item)) {
+        const itemStart = getItemStart(item);
 
-      item.top = getInitialHeight(item);
-
-      const horizontallyCollidingItems = [];
-      // Remove any items from the current stack if they have already ended
-      for(let i2 = currentStack.length - 1; i2 >= 0; i2--) {
-        const otherItem = currentStack[i2];
-        if(checkHorizontalOverlap(item, otherItem)) {
-          horizontallyCollidingItems.push(otherItem);
-          if(!checkVerticalOverlap) {
-            // If checkVerticalOverlap is present, we only care about the deepest stacked item which is horizontally overlapping
-            // This means it's not important to remove earlier items which are no longer horizontally overlapping
-            break;
-          }
-        } else {
-          currentStack.splice(i2, 1); // Safe because we're iterating over the array backwards
+        // We need to put immoveable items into itemsAlreadyPositioned and ensure that this array is sorted.
+        // We could simply insert them, and then use JavaScript's sort function to sort them afterwards.
+        // This would achieve an average complexity of O(n log n).
+        // 
+        // Instead, I'm gambling that the start of each item will usually be the same or later than the
+        // start of the previous item. While this holds (best case), we can insert items in O(n).
+        // In the worst case (where each item starts before the previous item) this grows to O(n^2).
+        // 
+        // I am making the assumption that for most datasets, the "order" function will have relatively low cardinality,
+        // and therefore this tradeoff should be easily worth it.
+        if(previousStart !== null && itemStart < previousStart - EPSILON) {
+          insertionIndex = 0;
         }
+        previousStart = itemStart;
+
+        insertionIndex = findIndexFrom(itemsAlreadyPositioned, i => getItemStart(i) - EPSILON > itemStart);
+
+        itemsAlreadyPositioned.splice(insertionIndex, 0, item);
+        insertionIndex++;
       }
+    }
+  }
 
-      // Iteratively attempt to find a location where the item does not collide with any other items
-      let collided;
-      do {
-        collided = false;
-        for(let i2 = 0; i2 < horizontallyCollidingItems.length; i2++) {
-          const otherItem = horizontallyCollidingItems[i2];
-          
-          if(!checkVerticalOverlap || checkVerticalOverlap(item, otherItem)) {
-            item.top = otherItem.top + otherItem.height + margins.vertical;
-            collided = true;
-            break;
-          }
-        }
-      } while(collided);
+  // Now we can loop through each item (in order) and find a position for them
+  previousStart = null;
+  insertionIndex = 0;
+  let horizontalOverlapStartIndex = 0;
+  let maxHeight = 0;
+  while(itemsToPosition.length > 0) {
+    const item = itemsToPosition.shift();
 
-      const currentHeight = item.top + item.height;
-      if(currentHeight > maxHeight) {
-        maxHeight = currentHeight;
+    item.top = getInitialHeight(item);
+
+    const itemStart = getItemStart(item);
+    const itemEnd = getItemEnd(item);
+    if(previousStart !== null && itemStart < previousStart - EPSILON) {
+      horizontalOverlapStartIndex = 0;
+      insertionIndex = 0;
+    }
+    previousStart = itemStart;
+
+    // Take advantage of the sorted itemsAlreadyPositioned array to narrow down the search
+    horizontalOverlapStartIndex = findIndexFrom(itemsAlreadyPositioned, i => itemStart < getItemEnd(i) - EPSILON, horizontalOverlapStartIndex);
+    let horizontalOverlapEndIndex = findIndexFrom(itemsAlreadyPositioned, i => itemEnd < getItemStart(i) - EPSILON, horizontalOverlapStartIndex);
+
+    // Sort by vertical position so we don't have to reconsider past items if we move an item
+    const horizontallyCollidingItems = itemsAlreadyPositioned
+      .slice(horizontalOverlapStartIndex, horizontalOverlapEndIndex)
+      .filter(i => itemStart < getItemEnd(i) - EPSILON && itemEnd - EPSILON > getItemStart(i))
+      .sort((a, b) => a.top - b.top);
+
+    // Keep moving the item down until it stops colliding with any other items
+    for(let i2 = 0; i2 < horizontallyCollidingItems.length; i2++) {
+      const otherItem = horizontallyCollidingItems[i2];
+      
+      if(checkVerticalSpatialCollision(item, otherItem, margins)) {
+        item.top = otherItem.top + otherItem.height + margins.vertical;
       }
     }
 
     if(shouldOthersStack(item)) {
-      currentStack.push(item);
-    }
-  }
-}
+      // Insert the item into itemsAlreadyPositioned, ensuring itemsAlreadyPositioned remains sorted.
+      // In the best case, we can insert an item in constant time O(1). In the worst case, we insert an item in linear time O(n).
+      // In both cases, this is better than doing a naive insert and then sort, which would cost on average O(n log n).
+      insertionIndex = findIndexFrom(itemsAlreadyPositioned, i => getItemStart(i) - EPSILON > itemStart);
 
-/**
- * Test if the two provided items collide
- * The items must have parameters left, width, top, and height.
- * @param {Item} a          The first item
- * @param {Item} b          The second item
- * @param {{horizontal: number}} margin
- *                          An object containing a horizontal and vertical
- *                          minimum required margin.
- * @param {boolean} rtl
- * @return {boolean}        true if a and b collide, else false
- */
-function checkHorizontalSpatialCollision(a, b, margin, rtl) {
-  if (rtl) {
-    return (a.right - margin.horizontal + EPSILON) < (b.right + b.width) &&
-    (a.right + a.width + margin.horizontal - EPSILON) > b.right;
-  } else {
-    return (a.left - margin.horizontal + EPSILON) < (b.left + b.width) &&
-    (a.left + a.width + margin.horizontal - EPSILON) > b.left;
+      itemsAlreadyPositioned.splice(insertionIndex, 0, item);
+      insertionIndex++;
+    }
+
+    // Keep track of the tallest item we've seen before
+    const currentHeight = item.top + item.height;
+    if(currentHeight > maxHeight) {
+      maxHeight = currentHeight;
+    }
+
+    if(shouldBail && shouldBail()) { return null; }
   }
+
+  return maxHeight;
 }
 
 /**
@@ -319,24 +349,24 @@ function checkVerticalSpatialCollision(a, b, margin) {
   (a.top + a.height + margin.vertical - EPSILON) > b.top;
 }
 
-/**
- * Test if the two provided objects collide
- * The objects must have parameters start, end, top, and height.
- * @param {Object} a          The first Object
- * @param {Object} b          The second Object
- * @return {boolean}        true if a and b collide, else false
- */
-function checkHorizontalTimeCollision(a, b) {
-  // Abutting is OK and not considered a collision, only overlap is considered a collision.
-  return a.start < b.end && a.end > b.start;
-}
 
-function compareSpatially(a, b) {
-  if(a.left > b.left) {
-    return 1;
+/**
+ * Find index of first item to meet predicate after a certain index.
+ * If no such item is found, returns the length of the array.
+ * 
+ * @param {any[]} arr The array
+ * @param {(item) => boolean} predicate A function that should return true when a suitable item is found
+ * @param {number|undefined} startIndex The index to start search from (inclusive). Optional, if not provided will search from the beginning of the array.
+ * 
+ * @return {number}
+ */
+function findIndexFrom(arr, predicate, startIndex) {
+  if(!startIndex) {
+    startIndex = 0;
   }
-  if(a.left < b.left) {
-    return -1;
+  const matchIndex = arr.slice(startIndex).findIndex(predicate);
+  if(matchIndex === -1) {
+    return arr.length;
   }
-  return 0;
+  return matchIndex + startIndex;
 }

--- a/lib/timeline/Stack.js
+++ b/lib/timeline/Stack.js
@@ -267,7 +267,7 @@ function performStacking(items, margins, compareTimes, shouldStack, shouldOthers
         }
         previousStart = itemStart;
 
-        insertionIndex = findIndexFrom(itemsAlreadyPositioned, i => getItemStart(i) - EPSILON > itemStart);
+        insertionIndex = findIndexFrom(itemsAlreadyPositioned, i => getItemStart(i) - EPSILON > itemStart, insertionIndex);
 
         itemsAlreadyPositioned.splice(insertionIndex, 0, item);
         insertionIndex++;
@@ -277,8 +277,10 @@ function performStacking(items, margins, compareTimes, shouldStack, shouldOthers
 
   // Now we can loop through each item (in order) and find a position for them
   previousStart = null;
+  let previousEnd = null;
   insertionIndex = 0;
   let horizontalOverlapStartIndex = 0;
+  let horizontalOverlapEndIndex = 0;
   let maxHeight = 0;
   while(itemsToPosition.length > 0) {
     const item = itemsToPosition.shift();
@@ -289,13 +291,21 @@ function performStacking(items, margins, compareTimes, shouldStack, shouldOthers
     const itemEnd = getItemEnd(item);
     if(previousStart !== null && itemStart < previousStart - EPSILON) {
       horizontalOverlapStartIndex = 0;
+      horizontalOverlapEndIndex = 0;
       insertionIndex = 0;
+      previousEnd = null;
     }
     previousStart = itemStart;
 
     // Take advantage of the sorted itemsAlreadyPositioned array to narrow down the search
     horizontalOverlapStartIndex = findIndexFrom(itemsAlreadyPositioned, i => itemStart < getItemEnd(i) - EPSILON, horizontalOverlapStartIndex);
-    let horizontalOverlapEndIndex = findIndexFrom(itemsAlreadyPositioned, i => itemEnd < getItemStart(i) - EPSILON, horizontalOverlapStartIndex);
+    // Since items aren't sorted by end time, it might increase or decrease from one item to the next. In order to keep an efficient search area, we will seek forwards/backwards accordingly.
+    if(previousEnd === null || previousEnd < itemEnd - EPSILON) {
+      horizontalOverlapEndIndex = findIndexFrom(itemsAlreadyPositioned, i => itemEnd < getItemStart(i) - EPSILON, Math.max(horizontalOverlapStartIndex, horizontalOverlapEndIndex));
+    }
+    if(previousEnd !== null && previousEnd - EPSILON > itemEnd) {
+      horizontalOverlapEndIndex = findLastIndexBetween(itemsAlreadyPositioned, i => itemEnd + EPSILON >= getItemStart(i), horizontalOverlapStartIndex, horizontalOVerlapEndIndex) + 1;
+    }
 
     // Sort by vertical position so we don't have to reconsider past items if we move an item
     const horizontallyCollidingItems = itemsAlreadyPositioned
@@ -316,7 +326,7 @@ function performStacking(items, margins, compareTimes, shouldStack, shouldOthers
       // Insert the item into itemsAlreadyPositioned, ensuring itemsAlreadyPositioned remains sorted.
       // In the best case, we can insert an item in constant time O(1). In the worst case, we insert an item in linear time O(n).
       // In both cases, this is better than doing a naive insert and then sort, which would cost on average O(n log n).
-      insertionIndex = findIndexFrom(itemsAlreadyPositioned, i => getItemStart(i) - EPSILON > itemStart);
+      insertionIndex = findIndexFrom(itemsAlreadyPositioned, i => getItemStart(i) - EPSILON > itemStart, insertionIndex);
 
       itemsAlreadyPositioned.splice(insertionIndex, 0, item);
       insertionIndex++;
@@ -369,4 +379,30 @@ function findIndexFrom(arr, predicate, startIndex) {
     return arr.length;
   }
   return matchIndex + startIndex;
+}
+
+/**
+ * Find index of last item to meet predicate within a given range.
+ * If no such item is found, returns the index prior to the start of the range.
+ * 
+ * @param {any[]} arr The array
+ * @param {(item) => boolean} predicate A function that should return true when a suitable item is found
+ * @param {number|undefined} startIndex The earliest index to search to (inclusive). Optional, if not provided will continue until the start of the array.
+ * @param {number|undefined} endIndex The end of the search range (exclusive). The search will begin on the index prior to this value. Optional, defaults to the end of array.
+ * 
+ * @return {number}
+ */
+function findLastIndexBetween(arr, predicate, startIndex, endIndex) {
+  if(!startIndex) {
+    startIndex = 0;
+  }
+  if(!endIndex) {
+    endIndex = arr.length;
+  }
+  for(i = endIndex - 1; i >= startIndex; i--) {
+    if(predicate(arr[i])) {
+      return i;
+    }
+  }
+  return startIndex - 1;
 }

--- a/lib/timeline/Stack.js
+++ b/lib/timeline/Stack.js
@@ -38,45 +38,21 @@ export function orderByEnd(items) {
  * @return {boolean} shouldBail
  */
 export function stack(items, margin, force, shouldBailItemsRedrawFunction) {
-  if (force) {
-    // reset top position of all items
-    for (var i = 0; i < items.length; i++) {
-      items[i].top = null;
-    }
-  }
+  const rtl = !!(items[0] && items[0].options.rtl);
+  items.sort((a, b) => compareSpatially(a, b) * (rtl ? -1 : 1));
+  const stackingResult = performStacking(
+    items,
+    margin.item,
+    item => item.stack && (force || item.top === null),
+    item => item.stack,
+    item => margin.axis,
+    (a, b) => checkHorizontalSpatialCollision(a, b, margin.item, b.options.rtl),
+    (a, b) => checkVerticalSpatialCollision(a, b, margin.item),
+    shouldBailItemsRedrawFunction
+  );
 
-  // calculate new, non-overlapping positions
-  for (var i = 0; i < items.length; i++) {  // eslint-disable-line no-redeclare
-    const item = items[i];
-    if (item.stack && item.top === null) {
-      // initialize top position
-      item.top = margin.axis;
-      var shouldBail = false;
-
-      do {
-        // TODO: optimize checking for overlap. when there is a gap without items,
-        //       you only need to check for items from the next item on, not from zero
-        var collidingItem = null;
-        for (let j = 0, jj = items.length; j < jj; j++) {
-          const other = items[j];
-          shouldBail = shouldBailItemsRedrawFunction() || false;
-
-          if (shouldBail) { return true; }
-
-          if (other.top !== null && other !== item && other.stack && collision(item, other, margin.item, other.options.rtl)) {
-            collidingItem = other;
-            break;
-          }
-        }
-
-        if (collidingItem != null) {
-          // There is a collision. Reposition the items above the colliding element
-          item.top = collidingItem.top + collidingItem.height + margin.item.vertical;
-        }
-      } while (collidingItem);
-    }
-  }
-  return shouldBail;
+  // If shouldBail function returned true during stacking calculation
+  return stackingResult === null;
 }
 
 /**
@@ -90,46 +66,17 @@ export function stack(items, margin, force, shouldBailItemsRedrawFunction) {
  *            The subgroup that is being stacked
  */
 export function substack(items, margin, subgroup) {
-  for (var i = 0; i < items.length; i++) {
-    items[i].top = null;
-  }
-
-  // Set the initial height
-  let subgroupHeight = subgroup.height;
-
-  // calculate new, non-overlapping positions
-  for (i = 0; i < items.length; i++) {
-    const item = items[i];
-
-    if (item.stack && item.top === null) {
-      // initialize top position
-      item.top = item.baseTop;//margin.axis + item.baseTop;
-
-      do {
-        // TODO: optimize checking for overlap. when there is a gap without items,
-        //       you only need to check for items from the next item on, not from zero
-        var collidingItem = null;
-        for (let j = 0, jj = items.length; j < jj; j++) {
-          const other = items[j];
-          if (other.top !== null && other !== item /*&& other.stack*/ && collision(item, other, margin.item, other.options.rtl)) {
-            collidingItem = other;
-            break;
-          }
-        }
-
-        if (collidingItem != null) {
-          // There is a collision. Reposition the items above the colliding element
-          item.top = collidingItem.top + collidingItem.height + margin.item.vertical;// + item.baseTop;
-        }
-
-        if (item.top + item.height > subgroupHeight) {
-          subgroupHeight = item.top + item.height;
-        }
-      } while (collidingItem);
-    }
-  }
-
-  // Set the new height
+  const rtl = !!(items[0] && items[0].options.rtl);
+  items.sort((a, b) => compareSpatially(a, b) * (rtl ? -1 : 1));
+  const subgroupHeight = performStacking(
+    items,
+    margin.item,
+    item => item.stack,
+    item => true,
+    item => item.baseTop,
+    (a, b) => checkHorizontalSpatialCollision(a, b, margin.item, b.options.rtl),
+    (a, b) => checkVerticalSpatialCollision(a, b, margin.item)
+  );
   subgroup.height = subgroupHeight - subgroup.top + 0.5 * margin.item.vertical;
 }
 
@@ -174,29 +121,23 @@ export function nostack(items, margin, subgroups, isStackSubgroups) {
  *            All subgroups
  */
 export function stackSubgroups(items, margin, subgroups) {
-  for (const subgroup in subgroups) {
-    if (subgroups.hasOwnProperty(subgroup)) {
+  performStacking(
+    Object.values(subgroups).sort((a, b) => {
+      if(a.index > b.index) return 1; 
+      if(a.index < b.index) return -1; 
+      return 0; 
+    }),
+    {
+      vertical: 0
+    },
+    item => true,
+    item => true,
+    item => 0,
+    (a, b) => checkHorizontalTimeCollision(a, b),
+    (a, b) => checkVerticalSpatialCollision(a, b, {vertical: 0}),
+    null
+  );
 
-
-      subgroups[subgroup].top = 0;
-      do {
-        // TODO: optimize checking for overlap. when there is a gap without items,
-        //       you only need to check for items from the next item on, not from zero
-        var collidingItem = null;
-        for (const otherSubgroup in subgroups) {
-          if (subgroups[otherSubgroup].top !== null && otherSubgroup !== subgroup && subgroups[subgroup].index > subgroups[otherSubgroup].index && collisionByTimes(subgroups[subgroup], subgroups[otherSubgroup])) {
-            collidingItem = subgroups[otherSubgroup];
-            break;
-          }
-        }
-
-        if (collidingItem != null) {
-          // There is a collision. Reposition the subgroups above the colliding element
-          subgroups[subgroup].top = collidingItem.top + collidingItem.height;
-        }
-      } while (collidingItem);
-    }
-  }
   for (let i = 0; i < items.length; i++) {
     if (items[i].data.subgroup !== undefined) {
       items[i].top = subgroups[items[i].data.subgroup].top + 0.5 * margin.item.vertical;
@@ -260,29 +201,122 @@ export function stackSubgroupsWithInnerStack(subgroupItems, margin, subgroups) {
   }
 }
 
+
+
+/**
+ * Reusable stacking function
+ * 
+ * @param {Item[]} items 
+ * An array of items to consider during stacking. Must be sorted by start time!
+ * @param {{horizontal: number, vertical: number}} margins
+ * Margins to be used for collision checking and placement of items.
+ * @param {(Item) => number | null} shouldStack
+ * A callback function which is called before we start to process an item. The return value indicates whether the item will be processed.
+ * @param {(Item) => boolean} shouldOthersStack
+ * A callback function which indicates whether other items should consider this item when being stacked.
+ * @param {(Item) => number} getInitialHeight
+ * A callback function which determines the height items are initially placed at
+ * @param {(Item, Item) => boolean} checkHorizontalOverlap
+ * A callback function which indicates whether two items overlap horizontally
+ * @param {(Item, Item) => boolean | null} checkVerticalOverlap
+ * A callback function which indicates whether two items overlap vertically.
+ * If null is specified, items will always be placed below any prior items that overlap horizontally.
+ * @param {() => boolean} shouldBail 
+ * A callback function which should indicate if the stacking process should be aborted.
+ * 
+ * @returns {null|number}
+ * if shouldBail was triggered, returns null
+ * otherwise, returns the maximum height
+ */
+ function performStacking(items, margins, shouldStack, shouldOthersStack, getInitialHeight, checkHorizontalOverlap, checkVerticalOverlap, shouldBail) {
+  const currentStack = [];
+  let maxHeight = 0;
+
+  for (var i = 0; i < items.length; i++) {
+    const item = items[i];
+
+    if(shouldStack(item)) {
+      if(shouldBail && shouldBail()) { return null; }
+
+      item.top = getInitialHeight(item);
+
+      const horizontallyCollidingItems = [];
+      // Remove any items from the current stack if they have already ended
+      for(let i2 = currentStack.length - 1; i2 >= 0; i2--) {
+        const otherItem = currentStack[i2];
+        if(checkHorizontalOverlap(item, otherItem)) {
+          horizontallyCollidingItems.push(otherItem);
+          if(!checkVerticalOverlap) {
+            // If checkVerticalOverlap is present, we only care about the deepest stacked item which is horizontally overlapping
+            // This means it's not important to remove earlier items which are no longer horizontally overlapping
+            break;
+          }
+        } else {
+          currentStack.splice(i2, 1); // Safe because we're iterating over the array backwards
+        }
+      }
+
+      // Iteratively attempt to find a location where the item does not collide with any other items
+      let collided;
+      do {
+        collided = false;
+        for(let i2 = 0; i2 < horizontallyCollidingItems.length; i2++) {
+          const otherItem = horizontallyCollidingItems[i2];
+          
+          if(!checkVerticalOverlap || checkVerticalOverlap(item, otherItem)) {
+            item.top = otherItem.top + otherItem.height + margins.vertical;
+            collided = true;
+            break;
+          }
+        }
+      } while(collided);
+
+      const currentHeight = item.top + item.height;
+      if(currentHeight > maxHeight) {
+        maxHeight = currentHeight;
+      }
+    }
+
+    if(shouldOthersStack(item)) {
+      currentStack.push(item);
+    }
+  }
+}
+
 /**
  * Test if the two provided items collide
  * The items must have parameters left, width, top, and height.
  * @param {Item} a          The first item
  * @param {Item} b          The second item
- * @param {{horizontal: number, vertical: number}} margin
+ * @param {{horizontal: number}} margin
  *                          An object containing a horizontal and vertical
  *                          minimum required margin.
  * @param {boolean} rtl
  * @return {boolean}        true if a and b collide, else false
  */
-export function collision(a, b, margin, rtl) {
+function checkHorizontalSpatialCollision(a, b, margin, rtl) {
   if (rtl) {
-    return  ((a.right - margin.horizontal + EPSILON)  < (b.right + b.width) &&
-    (a.right + a.width + margin.horizontal - EPSILON) > b.right &&
-    (a.top - margin.vertical + EPSILON)              < (b.top + b.height) &&
-    (a.top + a.height + margin.vertical - EPSILON)   > b.top);
+    return (a.right - margin.horizontal + EPSILON) < (b.right + b.width) &&
+    (a.right + a.width + margin.horizontal - EPSILON) > b.right;
   } else {
-    return ((a.left - margin.horizontal + EPSILON)   < (b.left + b.width) &&
-    (a.left + a.width + margin.horizontal - EPSILON) > b.left &&
-    (a.top - margin.vertical + EPSILON)              < (b.top + b.height) &&
-    (a.top + a.height + margin.vertical - EPSILON)   > b.top);
+    return (a.left - margin.horizontal + EPSILON) < (b.left + b.width) &&
+    (a.left + a.width + margin.horizontal - EPSILON) > b.left;
   }
+}
+
+/**
+ * Test if the two provided items collide
+ * The items must have parameters left, width, top, and height.
+ * @param {Item} a          The first item
+ * @param {Item} b          The second item
+ * @param {{vertical: number}} margin
+ *                          An object containing a horizontal and vertical
+ *                          minimum required margin.
+ * @return {boolean}        true if a and b collide, else false
+ */
+function checkVerticalSpatialCollision(a, b, margin) {
+  return (a.top - margin.vertical + EPSILON) < (b.top + b.height) &&
+  (a.top + a.height + margin.vertical - EPSILON) > b.top;
 }
 
 /**
@@ -292,11 +326,17 @@ export function collision(a, b, margin, rtl) {
  * @param {Object} b          The second Object
  * @return {boolean}        true if a and b collide, else false
  */
-export function collisionByTimes(a, b) {
+function checkHorizontalTimeCollision(a, b) {
+  // Abutting is OK and not considered a collision, only overlap is considered a collision.
+  return a.start < b.end && a.end > b.start;
+}
 
-  // Check for overlap by time and height. Abutting is OK and
-  // not considered a collision while overlap is considered a collision.
-  const timeOverlap = a.start < b.end && a.end > b.start;
-  const heightOverlap = a.top < (b.top + b.height) && (a.top + a.height) > b.top;
-  return timeOverlap && heightOverlap;
+function compareSpatially(a, b) {
+  if(a.left > b.left) {
+    return 1;
+  }
+  if(a.left < b.left) {
+    return -1;
+  }
+  return 0;
 }


### PR DESCRIPTION
fixes #1233

Well this was a fun challenge. This PR improves the performance of the stack, substack, and stackSubgroups functions. It also refactors them so that they all use a single common function.

I tested this against a ~1,600 item dataset. Before the change, stacking took 4.6 seconds. After the change it takes 84 milliseconds.

I think the new algorithm is O(n log n) for the best case (order of items matches chronological order) and O(n^2) for the worst case (order of items is the exact inverse of chronological order). I believe the previous stacking algorithm was actually O(n^2 log n), and not the O(n^2) mentioned in yotamberk/timeline-plus#26. But I'm not a computer scientist, so someone else would have to confirm this.

I have tested this using the "subgroups" example and it appears to maintain the same stacking behaviour. I've also tested it with a large dataset in my employer's application and it looks identical there too. But I realise that this isn't exactly extensive testing, so please let me know if there's anything I missed.