### PR TITLE
fix(data): primarily use public API idProp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,14 +55,46 @@ jobs:
       - run:
           name: Install dependencies for headless Chromium
           command: |
+            sudo apt-get update
             sudo apt-get install -yq \
-            ca-certificates fonts-liberation gconf-service libappindicator1 \
-            libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 \
-            libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 \
-            libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 \
-            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 \
-            libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 \
-            libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget \
+            ca-certificates \
+            fonts-liberation \
+            gconf-service \
+            libappindicator1 \
+            libasound2 \
+            libatk-bridge2.0-0 \
+            libatk1.0-0 \
+            libc6 \
+            libcairo2 \
+            libcups2 \
+            libdbus-1-3 \
+            libexpat1 \
+            libfontconfig1 \
+            libgcc1 \
+            libgconf-2-4 \
+            libgdk-pixbuf2.0-0 \
+            libglib2.0-0 \
+            libgtk-3-0 \
+            libnspr4 \
+            libnss3 \
+            libpango-1.0-0 \
+            libpangocairo-1.0-0 \
+            libstdc++6 \
+            libx11-6 \
+            libx11-xcb1 \
+            libxcb1 \
+            libxcomposite1 \
+            libxcursor1 \
+            libxdamage1 \
+            libxext6 \
+            libxfixes3 \
+            libxi6 \
+            libxrandr2 \
+            libxrender1 \
+            libxss1 \
+            libxtst6 \
+            lsb-release \
+            wget \
             xdg-utils
 
       - run: npm run generate-examples-index

--- a/lib/util.js
+++ b/lib/util.js
@@ -18,7 +18,7 @@ export function isDataViewLike(obj) {
     if(!obj) {
         return false;
     }
-    let idProp = obj._idProp;
+    let idProp = obj.idProp ?? obj._idProp;
     if(!idProp) {
         return false;
     }


### PR DESCRIPTION
The “private” _idProp has been removed and instead there idProp in the official supported API. I kept the older version there as a fallback just in case something actually depends on it.