### PR TITLE
fix(timeline.visibleFrameTemplate): fix regression

### DIFF
--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -399,7 +399,7 @@ class Item {
 
     if (this.options.visibleFrameTemplate) {
       visibleFrameTemplateFunction = this.options.visibleFrameTemplate.bind(this);
-      itemVisibleFrameContent = util.xss(visibleFrameTemplateFunction(itemData, itemVisibleFrameContentElement));
+      itemVisibleFrameContent = visibleFrameTemplateFunction(itemData, itemVisibleFrameContentElement);
     } else {
       itemVisibleFrameContent = '';
     }


### PR DESCRIPTION
Fixes the regression introduced in v7.4.4 that visibleFrameTemplate doesn't render HTML elements correctly.

closes: #1218