### PR TITLE
fix(horizontalOverlapEndIndex) typo in variable reference

### DIFF
--- a/lib/timeline/Stack.js
+++ b/lib/timeline/Stack.js
@@ -304,7 +304,7 @@ function performStacking(items, margins, compareTimes, shouldStack, shouldOthers
       horizontalOverlapEndIndex = findIndexFrom(itemsAlreadyPositioned, i => itemEnd < getItemStart(i) - EPSILON, Math.max(horizontalOverlapStartIndex, horizontalOverlapEndIndex));
     }
     if(previousEnd !== null && previousEnd - EPSILON > itemEnd) {
-      horizontalOverlapEndIndex = findLastIndexBetween(itemsAlreadyPositioned, i => itemEnd + EPSILON >= getItemStart(i), horizontalOverlapStartIndex, horizontalOVerlapEndIndex) + 1;
+      horizontalOverlapEndIndex = findLastIndexBetween(itemsAlreadyPositioned, i => itemEnd + EPSILON >= getItemStart(i), horizontalOverlapStartIndex, horizontalOverlapEndIndex) + 1;
     }
 
     // Sort by vertical position so we don't have to reconsider past items if we move an item


### PR DESCRIPTION
fix(horizontalOverlapEndIndex) typo in variable reference

variable `horizontalOverlapEndIndex` was incorrectly referenced as `horizontalOVerlapEndIndex`