### PR TITLE
Fix second time axis not using configured moment when added after the fact

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -457,7 +457,7 @@ class Core {
 
             if (this.options.orientation.axis === 'both') {
                 if (!this.timeAxis2) {
-                    const timeAxis2 = this.timeAxis2 = new TimeAxis(this.body);
+                    const timeAxis2 = this.timeAxis2 = new TimeAxis(this.body, this.options);
                     timeAxis2.setOptions = options => {
                         const _options = options ? util.extend({}, options) : {};
                         _options.orientation = 'top'; // override the orientation option, always top


### PR DESCRIPTION
This fixes #1640.  Not sure if there's a better approach, but it appears that if you initialize the timeline with a configured `moment`, and then after the fact set the orientation to `both`, the full options are never passed to the `TimeAxis`.

A minimal reproduction is available in the issue.
