### PR TITLE
TimelineItem.content can hold HTMLElement

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -751,7 +751,7 @@ export type TimelineItemEditableType = boolean | TimelineItemEditableOption;
 export interface TimelineItem {
   className?: string;
   align?: TimelineAlignType;
-  content: string;
+  content: string | HTMLElement;
   end?: DateType;
   group?: IdType;
   id: IdType;


### PR DESCRIPTION
The property `TimelineItem.content` can be of type `HTMLElement` as well as `string` (as demonstrated by the HTML sample). 

Note that the property `TimelineGroup.content` already is of this type `string | HTMLElement`.