### PR TITLE
Adding HTMLElement type to DataItem content

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,7 +86,7 @@ export interface LegendOptions {
 
 export interface DataItem {
   className?: string;
-  content: string;
+  content: string | HTMLElement;
   end?: DateType;
   group?: any;
   id?: IdType;


### PR DESCRIPTION
Vis-timeline in version 7.7.3 extended TimelineItem content to also include HTMLElement. [#e7f6aff0b11fdf89b9c54c59756933d7390b2ec1](https://github.com/visjs/vis-timeline/pull/1649/commits/e7f6aff0b11fdf89b9c54c59756933d7390b2ec1)

With this change, the react-vis-timeline will be compatible with the change in vis-timeline change.