### PR TITLE
DataItem content can have HTML Element

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,7 +86,7 @@ export interface LegendOptions {
 
 export interface DataItem {
   className?: string;
-  content: string;
+  content: string | HTMLElement;
   end?: DateType;
   group?: any;
   id?: IdType;


### PR DESCRIPTION
DataItem content property typescript definition should support HTMLElement similar to TimeLineItem
See https://github.com/visjs/vis-timeline/pull/1649 as a reference.