### PR TITLE
Typing fixes for options and Graph2d

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -270,6 +270,7 @@ export interface TimelineOptions {
   locale?: string;
   locales?: any; // TODO
   longSelectPressTime?: number,
+  loadingScreenTemplate?: () => string,
   moment?: MomentConstructor;
   margin?: TimelineOptionsMarginType;
   max?: DateType;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -463,8 +463,11 @@ export interface Graph2dOptions {
   end?: DateType;
   format?: any; // TODO
   graphHeight?: HeightWidthType;
+  /** Show/hide groups. To show/hide the ungrouped (default group) data, use the special `"__ungrouped__"` as `groupId`. */
+  groups?: { visibility: { [groupId: IdType]: boolean; } };
   height?: HeightWidthType;
   hiddenDates?: any; // TODO
+  interpolation?: boolean | ParametrizationInterpolationType;
   legend?: Graph2dLegendOption;
   locale?: string;
   locales?: any; // TODO
@@ -540,7 +543,13 @@ export class Graph2d {
 export interface Graph2d {
   setGroups(groups?: TimelineGroup[]): void;
   setItems(items?: TimelineItem[]): void;
-  getLegend(): TimelineWindow;
+  /**
+   * Retrieve legend icon (SVG, name and y-axis affiliation)
+   * @param groupId group id for which the legend icon and name should be returned
+   * @param iconWidth icon width
+   * @param iconHeight icon height
+   */
+  getLegend(groupId: IdType, iconWidth: number, iconHeight: number): { icon: SVGElement, label: string, orientation: 'left' | 'right' };
   getWindow(): TimelineWindow;
   setWindow(start: any, date: any): void;
   focus(selection: any): void;


### PR DESCRIPTION
- missing `Graph2dOptions` (matching the documentation and examples)
- fixed `Graph2d.getLegend(...)` typings
- missing `TimelineOptions.loadingScreenTemplate`