### PR TITLE
Timeline format labels funtion Date params to Moment type fix

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -668,8 +668,8 @@ function (option, path) {
         You can also use a function format for each label. The function accepts as arguments the date, scale and step in that order, and expects to return a string for the label.
 
         <pre class="prettyprint lang-js">function format({
-  minorLabels: Function(date: Date, scale: Number, step: Number),
-  majorLabels: Function(date: Date, scale: Number, step: Number)
+  minorLabels: Function(date: Moment, scale: Number, step: Number),
+  majorLabels: Function(date: Moment, scale: Number, step: Number)
 }</pre>
       </td>
     </tr>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -144,7 +144,7 @@ export interface TimelineEditableOption {
   overrideItems?: boolean;
 }
 
-export type TimelineFormatLabelsFunction = (date: Date, scale: string, step: number) => string;
+export type TimelineFormatLabelsFunction = (date: Moment, scale: string, step: number) => string;
 
 export interface TimelineFormatLabelsOption {
   millisecond?: string;


### PR DESCRIPTION
Hello, I am a user who has been finding vis-timeline very useful. I have encountered some inconveniences while using it and have decided to submit a PR.

- I would like to request a PR to modify the type of TimelineFormatLabelsFunction defined in TimelineOptions > format > minorLabels, majorLabels.
- The first date argument returned is not a Date object but a Moment object. I hope to fully utilize it by inferring the type as Moment.
- If not, it seems necessary to change the TimelineFormatLabelsFunction so that the first argument is returned as a Date. However, doing so seems like it would increase the workload, so I have opted for a simpler approach.
Relevant images and code


Relevant images and code
```ts
// use-case
    minorLabels: (date: Date, scale: string, step: number) => {
      console.log(date)
      return ""
    },
```

Displayed code
![image](https://github.com/visjs/vis-timeline/assets/60251579/3dd98b24-d707-49e7-9688-7bec5fd1c81d)


fix
- Change the first params type of the defined TimelineFormatLabelsFunction object to Moment.
