### PR TITLE
feat: Further improve performance of stack function

### DIFF
--- a/lib/timeline/Stack.js
+++ b/lib/timeline/Stack.js
@@ -295,10 +295,12 @@ function performStacking(items, margins, compareTimes, shouldStack, shouldOthers
       insertionIndex = 0;
       previousEnd = null;
     }
+    if(previousStart === null || itemStart > previousStart + EPSILON) {
+      // Take advantage of the sorted itemsAlreadyPositioned array to narrow down the search
+      horizontalOverlapStartIndex = findIndexFrom(itemsAlreadyPositioned, i => itemStart < getItemEnd(i) - EPSILON, horizontalOverlapStartIndex);
+    }
     previousStart = itemStart;
 
-    // Take advantage of the sorted itemsAlreadyPositioned array to narrow down the search
-    horizontalOverlapStartIndex = findIndexFrom(itemsAlreadyPositioned, i => itemStart < getItemEnd(i) - EPSILON, horizontalOverlapStartIndex);
     // Since items aren't sorted by end time, it might increase or decrease from one item to the next. In order to keep an efficient search area, we will seek forwards/backwards accordingly.
     if(previousEnd === null || previousEnd < itemEnd - EPSILON) {
       horizontalOverlapEndIndex = findIndexFrom(itemsAlreadyPositioned, i => itemEnd < getItemStart(i) - EPSILON, Math.max(horizontalOverlapStartIndex, horizontalOverlapEndIndex));
@@ -308,9 +310,12 @@ function performStacking(items, margins, compareTimes, shouldStack, shouldOthers
     }
 
     // Sort by vertical position so we don't have to reconsider past items if we move an item
-    const horizontallyCollidingItems = itemsAlreadyPositioned
-      .slice(horizontalOverlapStartIndex, horizontalOverlapEndIndex)
-      .filter(i => itemStart < getItemEnd(i) - EPSILON && itemEnd - EPSILON > getItemStart(i))
+    const horizontallyCollidingItems = filterBetween(
+      itemsAlreadyPositioned,
+      i => itemStart < getItemEnd(i) - EPSILON && itemEnd - EPSILON > getItemStart(i),
+      horizontalOverlapStartIndex,
+      horizontalOverlapEndIndex
+    )
       .sort((a, b) => a.top - b.top);
 
     // Keep moving the item down until it stops colliding with any other items
@@ -374,11 +379,12 @@ function findIndexFrom(arr, predicate, startIndex) {
   if(!startIndex) {
     startIndex = 0;
   }
-  const matchIndex = arr.slice(startIndex).findIndex(predicate);
-  if(matchIndex === -1) {
-    return arr.length;
+  for(var i = startIndex; i < arr.length; i++) {
+    if(predicate(arr[i])) {
+      return i;
+    }
   }
-  return matchIndex + startIndex;
+  return arr.length;
 }
 
 /**
@@ -399,10 +405,39 @@ function findLastIndexBetween(arr, predicate, startIndex, endIndex) {
   if(!endIndex) {
     endIndex = arr.length;
   }
-  for(i = endIndex - 1; i >= startIndex; i--) {
+  for(var i = endIndex - 1; i >= startIndex; i--) {
     if(predicate(arr[i])) {
       return i;
     }
   }
   return startIndex - 1;
+}
+
+/**
+ * Takes an array and returns an array containing only items which meet a predicate within a given range.
+ * 
+ * @param {any[]} arr The array
+ * @param {(item) => boolean} predicate A function that should return true for items which should be included within the result
+ * @param {number|undefined} startIndex The earliest index to include (inclusive). Optional, if not provided will continue until the start of the array.
+ * @param {number|undefined} endIndex The end of the range to filter (exclusive). Optional, defaults to the end of array.
+ * 
+ * @return {number}
+ */
+function filterBetween(arr, predicate, startIndex, endIndex) {
+  if(!startIndex) {
+    startIndex = 0;
+  }
+  if(endIndex) {
+    endIndex = Math.min(endIndex, arr.length);
+  } else {
+    endIndex = arr.length;
+  }
+
+  var result = [];
+  for(var i = startIndex; i < endIndex; i++) {
+    if(predicate(arr[i])) {
+      result.push(arr[i]);
+    }
+  }
+  return result;
 }

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -963,6 +963,8 @@ class Group {
       this._traceVisible(initialPosByEnd, orderedItems.byEnd, visibleItems, visibleItemsLookup, item => item.data.end < lowerBound || item.data.start > upperBound);
     }
 
+    this._sortVisibleItems(orderedItems.byStart, visibleItems, visibleItemsLookup);
+
     const redrawQueue = {};
     let redrawQueueLength = 0;
 
@@ -1030,6 +1032,23 @@ class Group {
             }
           }
         }
+      }
+    }
+  }
+
+  /**
+   * by-ref reordering of visibleItems array to match
+   * the specified item superset order
+   * @param {array} orderedItems
+   * @param {aray} visibleItems
+   * @param {object} visibleItemsLookup
+   */
+  _sortVisibleItems(orderedItems, visibleItems, visibleItemsLookup) {
+    visibleItems.length = 0; // Clear visibleItems array in-place
+    for(let i = 0; i < orderedItems.length; i++) {
+      let item = orderedItems[i];
+      if(visibleItemsLookup[item.id]) {
+        visibleItems.push(item);
       }
     }
   }

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -1011,7 +1011,7 @@ class Group {
           if (!(item.isCluster  && !item.hasItems()) && !item.cluster) {
             if (visibleItemsLookup[item.id] === undefined) {
               visibleItemsLookup[item.id] = true;
-              visibleItems.push(item);
+              visibleItems.unshift(item);
             }
           }
         }


### PR DESCRIPTION
I'm currently writing a blog post about the optimisations in my previous PR #1281. In the process of writing this blog post, I have identified several further minor performance improvements. During testing on a dataset of 6,000 items, these reduced time spent in the stacking function by an average of 15%.

This PR also partially exists to salvage my ego, because my benchmarks revealed that the fancy algorithm I wrote in #1281 actually performs worse (in some circumstances) than a naive algorithm I used for comparison. With the changes in this PR, the algorithm I worked hard on now confidently outperforms the naive algorithm in all circumstances I could think to test.