### PR TITLE
add year class to the timeline with month zoom

### DIFF
--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -701,6 +701,7 @@ class TimeStep {
         classNames.push(`vis-${current.format('MMMM').toLowerCase()}`);
         classNames.push(currentMonth(current));
         classNames.push(even(current.month()));
+        classNames.push(`vis-year${current.year()}`);
         break;
       case 'year':
         classNames.push(`vis-year${current.year()}`);


### PR DESCRIPTION
I'm trying to highlight calendar events (.ics file). There might be events for different years. 

<img width="542" alt="Screenshot 2025-04-29 at 16 30 32" src="https://github.com/user-attachments/assets/ccc99753-4d2a-478a-997b-fc63945ca072" />

Without this class I can't distinguished `29-04-2025` and `29-04-2026`