### PR TITLE
refactor(build): replace unmaintained rollup-plugin-css-porter by rollup-plugin-postcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "moment": "2.30.1",
         "nyc": "17.1.0",
         "propagating-hammerjs": "2.0.1",
-        "rollup-plugin-css-porter": "^1.0.2",
         "semantic-release": "22.0.12",
         "shx": "0.4.0",
         "snap-shot-it": "7.9.10",
@@ -5456,18 +5455,6 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
-    "node_modules/clean-css": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
-      "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -9576,6 +9563,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -14842,12 +14830,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.2.tgz",
-      "integrity": "sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ==",
-      "dev": true
-    },
     "node_modules/p-each-series": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -15212,16 +15194,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "dev": true,
-      "dependencies": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
       }
     },
     "node_modules/path-exists": {
@@ -16438,6 +16410,7 @@
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -17207,33 +17180,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup-plugin-css-porter": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-css-porter/-/rollup-plugin-css-porter-1.0.2.tgz",
-      "integrity": "sha512-efZ+uYsxUFDXwtbjw1sjiL6g1ymZVuLzteew62rmHxS46UWma2eDcK8k8n8c2MuyP2ulxjOM4YNX9X9Z0BYmAg==",
-      "dev": true,
-      "dependencies": {
-        "clean-css": "^4.2.1",
-        "fs-extra": "^7.0.1",
-        "os": "^0.1.1",
-        "path": "^0.12.7",
-        "rollup-pluginutils": "^2.4.1"
-      }
-    },
-    "node_modules/rollup-plugin-css-porter/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/rollup-plugin-postcss": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-4.0.2.tgz",
@@ -17623,6 +17569,7 @@
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
       "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "estree-walker": "^0.6.1"
       }
@@ -17631,7 +17578,8 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
@@ -19650,6 +19598,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -19720,25 +19669,10 @@
         "pako": "^1.0.11"
       }
     },
-    "node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "2.0.3"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
-    },
-    "node_modules/util/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "dev": true
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "moment": "2.30.1",
     "nyc": "17.1.0",
     "propagating-hammerjs": "2.0.1",
-    "rollup-plugin-css-porter": "^1.0.2",
     "semantic-release": "22.0.12",
     "shx": "0.4.0",
     "snap-shot-it": "7.9.10",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import nodeResolve from '@rollup/plugin-node-resolve';
 import babel from '@rollup/plugin-babel';
 import terser from '@rollup/plugin-terser';
 import { generateHeader } from 'vis-dev-utils';
-import css from 'rollup-plugin-css-porter';
+import css from "rollup-plugin-postcss";
 import copy from 'rollup-plugin-copy';
 import { BABEL_IGNORE_RE } from 'vis-dev-utils';
 
@@ -39,7 +39,8 @@ export default [{
 		nodeResolve({ browser: true }),
 		babel(babelConfig),
 		css({
-			dest: 'dist/vis-timeline-graph2d.css'
+			extract: 'vis-timeline-graph2d.css',
+			minimize: false,
 		}),
 		copyStatic
 	]
@@ -65,7 +66,8 @@ export default [{
 			}
 		}),
 		css({
-			dest: 'dist/vis-timeline-graph2d.css'
+			extract: 'vis-timeline-graph2d.min.css',
+			minimize: true,
 		}),
 		copyStatic
 	]


### PR DESCRIPTION
We also use this one for the other builds so it's not a new dependency.