### PR TITLE
refactor(styles): remove CSS from tests

### DIFF
--- a/lib/bundle-legacy.js
+++ b/lib/bundle-legacy.js
@@ -11,6 +11,23 @@ console.warn(
   ].join("\n")
 );
 
+// styles
+import "./shared/activator.css";
+import "./shared/bootstrap.css";
+import "./shared/configuration.css";
+import "./shared/tooltip.css";
+import "./timeline/component/css/animation.css";
+import "./timeline/component/css/currenttime.css";
+import "./timeline/component/css/customtime.css";
+import "./timeline/component/css/dataaxis.css";
+import "./timeline/component/css/item.css";
+import "./timeline/component/css/itemset.css";
+import "./timeline/component/css/labelset.css";
+import "./timeline/component/css/panel.css";
+import "./timeline/component/css/pathStyles.css";
+import "./timeline/component/css/timeaxis.css";
+import "./timeline/component/css/timeline.css";
+
 // locales
 import "moment/locale/de";
 import "moment/locale/es";

--- a/lib/entry-esnext.js
+++ b/lib/entry-esnext.js
@@ -1,5 +1,22 @@
 // Locales have to be supplied by the user.
 
+// styles
+import "./shared/activator.css";
+import "./shared/bootstrap.css";
+import "./shared/configuration.css";
+import "./shared/tooltip.css";
+import "./timeline/component/css/animation.css";
+import "./timeline/component/css/currenttime.css";
+import "./timeline/component/css/customtime.css";
+import "./timeline/component/css/dataaxis.css";
+import "./timeline/component/css/item.css";
+import "./timeline/component/css/itemset.css";
+import "./timeline/component/css/labelset.css";
+import "./timeline/component/css/panel.css";
+import "./timeline/component/css/pathStyles.css";
+import "./timeline/component/css/timeaxis.css";
+import "./timeline/component/css/timeline.css";
+
 // Timeline
 import Timeline from "./timeline/Timeline";
 import Graph2d from "./timeline/Graph2d";

--- a/lib/entry-standalone.js
+++ b/lib/entry-standalone.js
@@ -1,3 +1,20 @@
+// styles
+import "./shared/activator.css";
+import "./shared/bootstrap.css";
+import "./shared/configuration.css";
+import "./shared/tooltip.css";
+import "./timeline/component/css/animation.css";
+import "./timeline/component/css/currenttime.css";
+import "./timeline/component/css/customtime.css";
+import "./timeline/component/css/dataaxis.css";
+import "./timeline/component/css/item.css";
+import "./timeline/component/css/itemset.css";
+import "./timeline/component/css/labelset.css";
+import "./timeline/component/css/panel.css";
+import "./timeline/component/css/pathStyles.css";
+import "./timeline/component/css/timeaxis.css";
+import "./timeline/component/css/timeline.css";
+
 // locales
 import "moment/locale/de";
 import "moment/locale/es";

--- a/lib/shared/Activator.js
+++ b/lib/shared/Activator.js
@@ -3,8 +3,6 @@ import Emitter from 'component-emitter';
 import Hammer from '../module/hammer';
 import util from '../util';
 
-import './activator.css';
-
 /**
  * Turn an element into an clickToUse element.
  * When not active, the element has a transparent overlay. When the overlay is

--- a/lib/shared/Configurator.js
+++ b/lib/shared/Configurator.js
@@ -1,8 +1,6 @@
 import util from '../util';
 import ColorPicker from './ColorPicker';
 
-import './configuration.css';
-
 /**
  * The way this works is for all properties of this.possible options, you can supply the property name in any form to list the options.
  * Boolean options are recognised as Boolean

--- a/lib/shared/Popup.js
+++ b/lib/shared/Popup.js
@@ -1,5 +1,4 @@
 import util from '../util';
-import './tooltip.css';
 
 /**
  * Popup is a class to create a popup window with some text

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -7,13 +7,6 @@ import Activator from '../shared/Activator';
 import * as DateUtil from './DateUtil';
 import CustomTime from './component/CustomTime';
 
-import './component/css/animation.css';
-import './component/css/currenttime.css';
-import './component/css/panel.css';
-import './component/css/pathStyles.css';
-import './component/css/timeline.css';
-import '../shared/bootstrap.css';
-
 /**
  * Create a timeline visualization
  * @constructor Core

--- a/lib/timeline/component/CustomTime.js
+++ b/lib/timeline/component/CustomTime.js
@@ -4,8 +4,6 @@ import Component from './Component';
 import moment from '../../module/moment';
 import locales from '../locales';
 
-import './css/customtime.css';
-
 /** A custom time bar */
 class CustomTime extends Component {
  /**

--- a/lib/timeline/component/DataAxis.js
+++ b/lib/timeline/component/DataAxis.js
@@ -3,8 +3,6 @@ import * as DOMutil from '../../DOMutil';
 import Component from './Component';
 import DataScale from './DataScale';
 
-import './css/dataaxis.css';
-
 /** A horizontal time axis */
 class DataAxis extends Component {
   /**

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -12,9 +12,6 @@ import BackgroundItem from './item/BackgroundItem';
 import Popup from '../../shared/Popup';
 import ClusterGenerator from './ClusterGenerator';
 
-import './css/itemset.css';
-import './css/labelset.css';
-
 const UNGROUPED = '__ungrouped__';   // reserved group id for ungrouped items
 const BACKGROUND = '__background__'; // reserved group id for background items without group
 

--- a/lib/timeline/component/TimeAxis.js
+++ b/lib/timeline/component/TimeAxis.js
@@ -4,8 +4,6 @@ import TimeStep from '../TimeStep';
 import * as DateUtil  from '../DateUtil';
 import moment from '../../module/moment';
 
-import './css/timeaxis.css';
-
 /** A horizontal time axis */
 class TimeAxis extends Component {
 /**

--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -3,8 +3,6 @@ import util from '../../../util';
 import moment from '../../../module/moment';
 import locales from '../../locales';
 
-import '../css/item.css';
-
 /**
  * Item
  */


### PR DESCRIPTION
Tests run in Node without CSS support. The style imports were ignored anyway. Not importing CSS into tests in the first place will make things easier, especially transition to ESM where require won't work.