### PR TITLE
fix(range): disable rolling mode on focus

### DIFF
--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -529,6 +529,7 @@ export default class Timeline extends Core {
         initialVerticalScroll = { shouldScroll: false, scrollOffset: -1, itemTop: -1 };
       }
 
+      this.range.stopRolling();
       this.range.setRange(middle - interval / 2, middle + interval / 2, { animation }, finalVerticalCallback, verticalAnimationFrame);
     }
   }


### PR DESCRIPTION
Rolling mode keeps the current time centered. Using focus while rolling mode is engaged doesn't make any sense. If the user uses focus while rolling mode is engaged, it does make sense to automatically disengage rolling mode.

Fixes #573