### PR TITLE
Fix ReferenceError when clicking custom markers

### DIFF
--- a/lib/timeline/component/CustomTime.js
+++ b/lib/timeline/component/CustomTime.js
@@ -213,18 +213,18 @@ class CustomTime extends Component {
 
     if (editable) {
       this.marker.setAttribute('contenteditable', 'true');
-      this.marker.addEventListener('pointerdown', function () {
+      this.marker.addEventListener('pointerdown', () => {
         this.marker.focus();
       });
       this.marker.addEventListener('input', this._onMarkerChange.bind(this));
       // The editable div element has no change event, so here emulates the change event.
       this.marker.title = title;
-      this.marker.addEventListener('blur', function (event) {
+      this.marker.addEventListener('blur', event => {
         if (this.title != event.target.innerHTML) {
           this._onMarkerChanged(event);
           this.title = event.target.innerHTML;
         }
-      }.bind(this));
+      });
     }
 
     this.bar.appendChild(this.marker);


### PR DESCRIPTION
fixes #1739 

This PR resolves a ReferenceError that occurs when clicking on custom markers. The issue was introduced in #367, where all `marker` references were updated to use `this`. However, a classic `function(){}` expression was used for an event listener without proper `this` binding, leading to the error.

To fix this, I updated it (and other existing one) to use an arrow function. I think it is better than `.bind(this)` nowadays.