### PR TITLE
Increase EPSILON to Prevent Overlaps and Overflow

### DIFF
--- a/lib/timeline/Stack.js
+++ b/lib/timeline/Stack.js
@@ -1,5 +1,6 @@
 // Utility functions for ordering and stacking of items
-const EPSILON = 0.001; // used when checking collisions, to prevent round-off errors
+//Found empirically, in order to avoid unnecessary overlaps and ensure that no element overflow occurs
+const EPSILON = 1; // used when checking collisions, to prevent round-off errors
 
 /**
  * Order items by their start data


### PR DESCRIPTION
The value of EPSILON was changed from 0.001 to 1 to avoid unnecessary overlaps and prevent element overflow during collision detection.
