### PR TITLE
Quality: Missing `this` binding or context check

### DIFF
--- a/lib/timeline/component/Component.js
+++ b/lib/timeline/component/Component.js
@@ -43,6 +43,8 @@ export default class Component {
    * @protected
    */
   _isResized() {
+    if (!this.props) return false;
+
     const resized =
       this.props._previousWidth !== this.props.width ||
       this.props._previousHeight !== this.props.height;


### PR DESCRIPTION
## Summary

Quality: Missing `this` binding or context check

## Problem

**Severity**: `Medium` | **File**: `lib/timeline/component/Component.js:L46`

The `_isResized` method accesses `this.props._previousWidth` and `this.props.width`. If `this.props` is `null` (as initialized in the constructor), this method will throw a `TypeError`.

## Solution

Add a guard clause to check if `this.props` exists before accessing its properties, or ensure `this.props` is always an object.

## Changes

- `lib/timeline/component/Component.js` (modified)