### PR TITLE
fix(timeline-group): always check all items instead of relying on binary search

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -1028,18 +1028,6 @@ class Group {
       }
     };
 
-    // this function is used to do the binary search for items having start and end dates (range).
-    const endSearchFunction = (data) => {
-      const { start, end } = data;
-      if (end < lowerBound) {
-        return -1;
-      } else if (start <= upperBound) {
-        return 0;
-      } else {
-        return 1;
-      }
-    };
-
     // first check if the items that were in view previously are still in view.
     // IMPORTANT: this handles the case for the items with startdate before the window and enddate after the window!
     // also cleans up invisible items.
@@ -1071,33 +1059,13 @@ class Group {
       (item) => item.data.start < lowerBound || item.data.start > upperBound,
     );
 
-    // if the window has changed programmatically without overlapping the old window, the ranged items with start < lowerBound and end > upperbound are not shown.
-    // We therefore have to brute force check all items in the byEnd list
-    if (this.checkRangedItems == true) {
-      this.checkRangedItems = false;
-      for (let i = 0; i < orderedItems.byEnd.length; i++) {
-        this._checkIfVisibleWithReference(
-          orderedItems.byEnd[i],
-          visibleItems,
-          visibleItemsLookup,
-          range,
-        );
-      }
-    } else {
-      // we do a binary search for the items that have defined end times.
-      const initialPosByEnd = util.binarySearchCustom(
-        orderedItems.byEnd,
-        endSearchFunction,
-        "data",
-      );
-
-      // trace the visible items from the inital start pos both ways until an invisible item is found, we only look at the end values.
-      this._traceVisible(
-        initialPosByEnd,
-        orderedItems.byEnd,
+    // check every item with end date if is visible. Binary search would be the most efficient, but it would leave out items that start before the range and end after the range.
+    for (let i = 0; i < orderedItems.byEnd.length; i++) {
+      this._checkIfVisibleWithReference(
+        orderedItems.byEnd[i],
         visibleItems,
         visibleItemsLookup,
-        (item) => item.data.end < lowerBound || item.data.start > upperBound,
+        range,
       );
     }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import terser from "@rollup/plugin-terser";
 import copy from "rollup-plugin-copy";
 import css from "rollup-plugin-postcss";
 
-import { generateHeader, BABEL_IGNORE_RE } from "vis-dev-utils";
+import { BABEL_IGNORE_RE, generateHeader } from "vis-dev-utils";
 
 const banner = generateHeader({ name: "vis-timeline and vis-graph2d" });
 


### PR DESCRIPTION
Binary search is faster but since the items have starts and ends, there are cases where it jumps over items which have start before the range and end after the range. I don't think a binary search solution is possible here. Since the checks themselves are rather fast, there most likely isn't much of a reason to employ a more complex solution.

Example: Item 7 starts and ends after the range, should be discarded and correctly is. Items 8+ are then discarded too. They all end after the range since the data is sorted by end, this is guaranteed. However, the assumption that they all start after the range simply because item 7 does is false. Some are discarded when they shouldn't.

Fixes #1657
Closes #1846

This solution was copy-pasted from @ChristianKrebel's #1846 but that doesn't apply against currect master and I don't have a permission to edit the PR.