### PR TITLE
fix(types): reexport hammerjs types from @egjs/hammerjs

### DIFF
--- a/types/entry-standalone.d.ts
+++ b/types/entry-standalone.d.ts
@@ -6,7 +6,7 @@ export { util };
 
 import moment from "moment";
 export { moment };
-import Hammer from "hammerjs";
+import Hammer from "@egjs/hammerjs";
 export { Hammer };
 import keycharm from "keycharm";
 export { keycharm };


### PR DESCRIPTION
We use @egjs/hammerjs in runtime so it makes sense to also reexport the types from there even if they are structurally identical.