### PR TITLE
Make the stacking collision-detection epsilon configurable

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1129,6 +1129,39 @@ function groupOrderSwap(fromGroup: Object, toGroup: Object, groups: DataSet)</pr
           <td><code>10</code></td>
           <td>The minimal vertical margin in pixels between items.</td>
         </tr>
+        <tr parent="margin" class="hidden">
+          <td class="indent">margin.epsilon</td>
+          <td>number or Object</td>
+          <td><code>0.001</code></td>
+          <td>
+            Tolerance in pixels used when checking collisions during stacking,
+            to prevent round-off errors. Increase it if items that should be
+            considered touching or overlapping (for example due to sub-pixel
+            rounding) are instead stacked on separate rows; decrease it if items
+            that are genuinely distinct end up merged onto the same row. When a
+            number, applies the value to both
+            <code>margin.epsilon.horizontal</code> and
+            <code>margin.epsilon.vertical</code>.
+          </td>
+        </tr>
+        <tr parent="margin" class="hidden">
+          <td class="indent2">margin.epsilon.horizontal</td>
+          <td>number</td>
+          <td><code>0.001</code></td>
+          <td>
+            Tolerance in pixels used for horizontal (start/end, or left/right)
+            collision checks.
+          </td>
+        </tr>
+        <tr parent="margin" class="hidden">
+          <td class="indent2">margin.epsilon.vertical</td>
+          <td>number</td>
+          <td><code>0.001</code></td>
+          <td>
+            Tolerance in pixels used for the vertical (top/height) collision
+            check that decides whether items are pushed onto separate rows.
+          </td>
+        </tr>
 
         <tr>
           <td>max</td>

--- a/lib/timeline/Stack.js
+++ b/lib/timeline/Stack.js
@@ -1,5 +1,9 @@
 // Utility functions for ordering and stacking of items
-const EPSILON = 0.001; // used when checking collisions, to prevent round-off errors
+
+// Used when checking collisions, to prevent round-off errors. Configurable via
+// the `margin.epsilon` timeline option, these are the fallbacks when it isn't set.
+const DEFAULT_EPSILON_HORIZONTAL = 0.001;
+const DEFAULT_EPSILON_VERTICAL = 0.001;
 
 /**
  * Order items by their start data
@@ -46,6 +50,8 @@ export function stack(items, margin, force, shouldBailItemsRedrawFunction) {
     (item) => item.stack,
     () => margin.axis,
     shouldBailItemsRedrawFunction,
+    margin.epsilon && margin.epsilon.horizontal,
+    margin.epsilon && margin.epsilon.vertical,
   );
 
   // If shouldBail function returned true during stacking calculation
@@ -70,6 +76,9 @@ export function substack(items, margin, subgroup) {
     (item) => item.stack,
     () => true,
     (item) => item.baseTop,
+    undefined,
+    margin.epsilon && margin.epsilon.horizontal,
+    margin.epsilon && margin.epsilon.vertical,
   );
   subgroup.height = subgroupHeight - subgroup.top + 0.5 * margin.item.vertical;
 }
@@ -132,6 +141,9 @@ export function stackSubgroups(items, margin, subgroups) {
     () => true,
     () => true,
     () => 0,
+    undefined,
+    margin.epsilon && margin.epsilon.horizontal,
+    margin.epsilon && margin.epsilon.vertical,
   );
 
   for (let i = 0; i < items.length; i++) {
@@ -215,6 +227,12 @@ export function stackSubgroupsWithInnerStack(subgroupItems, margin, subgroups) {
  * A callback function which determines the height items are initially placed at
  * @param {function(): boolean} shouldBail
  * A callback function which should indicate if the stacking process should be aborted.
+ * @param {number} [epsilon]
+ * Tolerance used for horizontal (start/end, or left/right) collision checks, to prevent
+ * round-off errors. Defaults to DEFAULT_EPSILON_HORIZONTAL.
+ * @param {number} [verticalEpsilon]
+ * Tolerance used for the vertical (top/height) collision check, to prevent round-off
+ * errors. Defaults to DEFAULT_EPSILON_VERTICAL.
  *
  * @returns {null|number}
  * if shouldBail was triggered, returns null
@@ -228,7 +246,16 @@ function performStacking(
   shouldOthersStack,
   getInitialHeight,
   shouldBail,
+  epsilon,
+  verticalEpsilon,
 ) {
+  if (epsilon == null) {
+    epsilon = DEFAULT_EPSILON_HORIZONTAL;
+  }
+  if (verticalEpsilon == null) {
+    verticalEpsilon = DEFAULT_EPSILON_VERTICAL;
+  }
+
   // Time-based horizontal comparison
   let getItemStart = (item) => item.start;
   let getItemEnd = (item) => item.end;
@@ -271,14 +298,14 @@ function performStacking(
         //
         // I am making the assumption that for most datasets, the "order" function will have relatively low cardinality,
         // and therefore this tradeoff should be easily worth it.
-        if (previousStart !== null && itemStart < previousStart - EPSILON) {
+        if (previousStart !== null && itemStart < previousStart - epsilon) {
           insertionIndex = 0;
         }
         previousStart = itemStart;
 
         insertionIndex = findIndexFrom(
           itemsAlreadyPositioned,
-          (i) => getItemStart(i) - EPSILON > itemStart,
+          (i) => getItemStart(i) - epsilon > itemStart,
           insertionIndex,
         );
 
@@ -302,35 +329,35 @@ function performStacking(
 
     const itemStart = getItemStart(item);
     const itemEnd = getItemEnd(item);
-    if (previousStart !== null && itemStart < previousStart - EPSILON) {
+    if (previousStart !== null && itemStart < previousStart - epsilon) {
       horizontalOverlapStartIndex = 0;
       horizontalOverlapEndIndex = 0;
       insertionIndex = 0;
       previousEnd = null;
     }
-    if (previousStart === null || itemStart > previousStart + EPSILON) {
+    if (previousStart === null || itemStart > previousStart + epsilon) {
       // Take advantage of the sorted itemsAlreadyPositioned array to narrow down the search
       horizontalOverlapStartIndex = findIndexFrom(
         itemsAlreadyPositioned,
-        (i) => itemStart < getItemEnd(i) - EPSILON,
+        (i) => itemStart < getItemEnd(i) - epsilon,
         horizontalOverlapStartIndex,
       );
     }
     previousStart = itemStart;
 
     // Since items aren't sorted by end time, it might increase or decrease from one item to the next. In order to keep an efficient search area, we will seek forwards/backwards accordingly.
-    if (previousEnd === null || previousEnd < itemEnd - EPSILON) {
+    if (previousEnd === null || previousEnd < itemEnd - epsilon) {
       horizontalOverlapEndIndex = findIndexFrom(
         itemsAlreadyPositioned,
-        (i) => itemEnd < getItemStart(i) - EPSILON,
+        (i) => itemEnd < getItemStart(i) - epsilon,
         Math.max(horizontalOverlapStartIndex, horizontalOverlapEndIndex),
       );
     }
-    if (previousEnd !== null && previousEnd - EPSILON > itemEnd) {
+    if (previousEnd !== null && previousEnd - epsilon > itemEnd) {
       horizontalOverlapEndIndex =
         findLastIndexBetween(
           itemsAlreadyPositioned,
-          (i) => itemEnd + EPSILON >= getItemStart(i),
+          (i) => itemEnd + epsilon >= getItemStart(i),
           horizontalOverlapStartIndex,
           horizontalOverlapEndIndex,
         ) + 1;
@@ -340,7 +367,7 @@ function performStacking(
     // Sort by vertical position so we don't have to reconsider past items if we move an item
     const horizontallyCollidingItems = filterBetween(
       itemsAlreadyPositioned,
-      (i) => itemStart < getItemEnd(i) - EPSILON,
+      (i) => itemStart < getItemEnd(i) - epsilon,
       horizontalOverlapStartIndex,
       horizontalOverlapEndIndex,
     ).toSorted((a, b) => a.top - b.top);
@@ -349,7 +376,9 @@ function performStacking(
     for (let i2 = 0; i2 < horizontallyCollidingItems.length; i2++) {
       const otherItem = horizontallyCollidingItems[i2];
 
-      if (checkVerticalSpatialCollision(item, otherItem, margins)) {
+      if (
+        checkVerticalSpatialCollision(item, otherItem, margins, verticalEpsilon)
+      ) {
         item.top = otherItem.top + otherItem.height + margins.vertical;
       }
     }
@@ -360,7 +389,7 @@ function performStacking(
       // In both cases, this is better than doing a naive insert and then sort, which would cost on average O(n log n).
       insertionIndex = findIndexFrom(
         itemsAlreadyPositioned,
-        (i) => getItemStart(i) - EPSILON > itemStart,
+        (i) => getItemStart(i) - epsilon > itemStart,
         insertionIndex,
       );
 
@@ -399,12 +428,13 @@ function performStacking(
  * @param {{vertical: number}} margin
  *                          An object containing a horizontal and vertical
  *                          minimum required margin.
+ * @param {number} epsilon  Vertical tolerance used when checking collisions, to prevent round-off errors.
  * @return {boolean}        true if a and b collide, else false
  */
-function checkVerticalSpatialCollision(a, b, margin) {
+function checkVerticalSpatialCollision(a, b, margin, epsilon) {
   return (
-    a.top - margin.vertical + EPSILON < b.top + b.height &&
-    a.top + a.height + margin.vertical - EPSILON > b.top
+    a.top - margin.vertical + epsilon < b.top + b.height &&
+    a.top + a.height + margin.vertical - epsilon > b.top
   );
 }
 

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -112,6 +112,15 @@ class ItemSet extends Component {
           vertical: 10,
         },
         axis: 20,
+        // Tolerance used when checking collisions during stacking, to prevent round-off
+        // errors. `horizontal` governs start/end (or left/right) overlap checks, `vertical`
+        // governs the top/height collision check that decides whether items are pushed onto
+        // separate rows. Can be increased to make near-touching items snap together instead
+        // of stacking, at the cost of treating items within `epsilon` pixels as overlapping.
+        epsilon: {
+          horizontal: 0.001,
+          vertical: 0.001,
+        },
       },
 
       showTooltips: true,
@@ -493,6 +502,18 @@ class ItemSet extends Component {
                 ["horizontal", "vertical"],
                 this.options.margin.item,
                 options.margin.item,
+              );
+            }
+          }
+          if ("epsilon" in options.margin) {
+            if (typeof options.margin.epsilon === "number") {
+              this.options.margin.epsilon.horizontal = options.margin.epsilon;
+              this.options.margin.epsilon.vertical = options.margin.epsilon;
+            } else if (typeof options.margin.epsilon === "object") {
+              util.selectiveExtend(
+                ["horizontal", "vertical"],
+                this.options.margin.epsilon,
+                options.margin.epsilon,
               );
             }
           }
@@ -929,10 +950,12 @@ class ItemSet extends Component {
     const firstMargin = {
       item: margin.item,
       axis: margin.axis,
+      epsilon: margin.epsilon,
     };
     const nonFirstMargin = {
       item: margin.item,
       axis: margin.item.vertical / 2,
+      epsilon: margin.epsilon,
     };
     let height = 0;
     const minHeight = margin.axis + margin.item.vertical;

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -117,6 +117,11 @@ const allOptions = {
       vertical: { number, undefined: "undefined" },
       __type__: { object, number },
     },
+    epsilon: {
+      horizontal: { number, undefined: "undefined" },
+      vertical: { number, undefined: "undefined" },
+      __type__: { object, number },
+    },
     __type__: { object, number },
   },
   max: { date, number, string, moment },
@@ -264,6 +269,10 @@ const configureOptions = {
       item: {
         horizontal: [10, 0, 100, 1],
         vertical: [10, 0, 100, 1],
+      },
+      epsilon: {
+        horizontal: [0.001, 0, 5, 0.001],
+        vertical: [0.001, 0, 5, 0.001],
       },
     },
     max: "",

--- a/test/Stack.test.js
+++ b/test/Stack.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import { stack } from "../lib/timeline/Stack.js";
+import { stack, substack } from "../lib/timeline/Stack.js";
 
 /**
  * Builds a minimal fake Item as expected by Stack.js: only the properties
@@ -13,10 +13,11 @@ import { stack } from "../lib/timeline/Stack.js";
  * @param {number|null} [options.top]
  * @returns {object} a fake Item
  */
-function makeItem({ left, width, height, top = null }) {
+function makeItem({ left, width, height, top = null, baseTop }) {
   return {
     stack: true,
     top,
+    baseTop,
     left,
     width,
     height,
@@ -126,6 +127,81 @@ describe("Stack", () => {
         0,
         "b is left overlapping a on screen, the vertical check never even runs for this pair",
       );
+    });
+  });
+
+  describe("substack() (used for items inside a stacked subgroup)", () => {
+    // Same idea as the plain stack() vertical-epsilon scenario above, but
+    // going through substack()/baseTop instead of stack()/margin.axis, since
+    // subgroups position their items independently of the main stack().
+    function verticalOverlapScenario(verticalEpsilon) {
+      const first = makeItem({
+        left: 0,
+        width: 100,
+        height: 10,
+        baseTop: 10,
+      });
+      const second = makeItem({
+        left: 0,
+        width: 100,
+        height: 10.5,
+        baseTop: 0,
+      });
+      const margin = {
+        item: { horizontal: 0, vertical: 0 },
+        epsilon: { horizontal: 0.001, vertical: verticalEpsilon },
+      };
+
+      substack([first, second], margin, { top: 0 });
+      return { first, second };
+    }
+
+    it("with the default tolerance, a genuine small overlap pushes the second item onto its own row", () => {
+      const { first, second } = verticalOverlapScenario(0.001);
+
+      assert.equal(first.top, 10);
+      assert.equal(second.top, 20);
+    });
+
+    it("with a larger tolerance, the same overlap is tolerated and the item keeps its baseTop", () => {
+      const { first, second } = verticalOverlapScenario(1);
+
+      assert.equal(first.top, 10);
+      assert.equal(second.top, 0);
+    });
+  });
+
+  describe("boundary semantics: collision requires a *strictly* larger overlap than epsilon", () => {
+    // Same fixture as the plain stack() vertical-epsilon scenario, but
+    // parameterized on the exact vertical overlap between `incoming` and
+    // `fixed`, to pin down the `>` vs `>=` boundary.
+    function withOverlap(overlap, verticalEpsilon) {
+      const fixed = makeItem({ left: 0, width: 100, height: 10, top: 10 });
+      const incoming = makeItem({
+        left: 0,
+        width: 100,
+        height: 10 + overlap,
+      });
+      const margin = {
+        item: { horizontal: 0, vertical: 0 },
+        axis: 0,
+        epsilon: { horizontal: 0.001, vertical: verticalEpsilon },
+      };
+
+      stack([fixed, incoming], margin, false, null);
+      return incoming.top;
+    }
+
+    it("an overlap smaller than epsilon is not a collision", () => {
+      assert.equal(withOverlap(0.4, 0.5), 0);
+    });
+
+    it("an overlap exactly equal to epsilon is not a collision (strict inequality)", () => {
+      assert.equal(withOverlap(0.5, 0.5), 0);
+    });
+
+    it("an overlap larger than epsilon is a collision", () => {
+      assert.equal(withOverlap(0.6, 0.5), 20);
     });
   });
 });

--- a/test/Stack.test.js
+++ b/test/Stack.test.js
@@ -1,0 +1,131 @@
+import assert from "node:assert";
+
+import { stack } from "../lib/timeline/Stack.js";
+
+/**
+ * Builds a minimal fake Item as expected by Stack.js: only the properties
+ * actually read by performStacking()/checkVerticalSpatialCollision() are
+ * needed, no DOM or Item class required.
+ * @param {object} options
+ * @param {number} options.left
+ * @param {number} options.width
+ * @param {number} options.height
+ * @param {number|null} [options.top]
+ * @returns {object} a fake Item
+ */
+function makeItem({ left, width, height, top = null }) {
+  return {
+    stack: true,
+    top,
+    left,
+    width,
+    height,
+    options: { rtl: false },
+    data: {},
+  };
+}
+
+/**
+ * @param {object} margin
+ * @param {{item: object[], force?: boolean}} config
+ * @returns {object[]} the same items, mutated in place with their computed `top`
+ */
+function runStack(margin, { items, force = true }) {
+  stack(items, margin, force, null);
+  return items;
+}
+
+describe("Stack", () => {
+  describe("margin.epsilon (backward compatibility)", () => {
+    it("defaults to 0.001 for both axes when margin.epsilon is not provided", () => {
+      // Two fully overlapping items: without any epsilon override the
+      // second item must still be pushed onto its own row, exactly like
+      // before this option existed (EPSILON was hardcoded to 0.001).
+      const a = makeItem({ left: 0, width: 100, height: 20 });
+      const b = makeItem({ left: 0, width: 100, height: 20 });
+      const margin = { item: { horizontal: 0, vertical: 0 }, axis: 0 };
+
+      runStack(margin, { items: [a, b] });
+
+      assert.equal(a.top, 0);
+      assert.equal(b.top, 20);
+    });
+  });
+
+  describe("margin.epsilon.vertical", () => {
+    // The incoming item genuinely overlaps the already-positioned item by
+    // 0.5px vertically (occupies 0..10.5, the fixed item occupies 10..20).
+    function verticalOverlapScenario(verticalEpsilon) {
+      const fixed = makeItem({ left: 0, width: 100, height: 10, top: 10 });
+      const incoming = makeItem({ left: 0, width: 100, height: 10.5 });
+      const margin = {
+        item: { horizontal: 0, vertical: 0 },
+        axis: 0,
+        epsilon: { horizontal: 0.001, vertical: verticalEpsilon },
+      };
+
+      // force=false: `fixed` already has a top and is left untouched, only
+      // `incoming` (top===null) gets (re)positioned - this is the normal
+      // "add one more item" redraw path.
+      runStack(margin, { items: [fixed, incoming], force: false });
+      return { fixed, incoming };
+    }
+
+    it("with the default (tight) tolerance, a genuine small overlap is detected and the item is pushed to a new row", () => {
+      const { fixed, incoming } = verticalOverlapScenario(0.001);
+
+      assert.equal(fixed.top, 10);
+      assert.equal(
+        incoming.top,
+        20,
+        "incoming item should be pushed below fixed",
+      );
+    });
+
+    it("with a larger tolerance, the same overlap is now treated as non-colliding and the item stays put", () => {
+      const { fixed, incoming } = verticalOverlapScenario(1);
+
+      assert.equal(fixed.top, 10);
+      assert.equal(
+        incoming.top,
+        0,
+        "incoming item is left overlapping fixed on screen by 0.5px",
+      );
+    });
+  });
+
+  describe("margin.epsilon.horizontal", () => {
+    // `b` overlaps `a` by 0.5px horizontally (a occupies [0, 10], b occupies
+    // [9.5, 19.5]) and fully overlaps it vertically (same height, no top yet).
+    function horizontalOverlapScenario(horizontalEpsilon) {
+      const a = makeItem({ left: 0, width: 10, height: 20 });
+      const b = makeItem({ left: 9.5, width: 10, height: 20 });
+      const margin = {
+        item: { horizontal: 0, vertical: 0 },
+        axis: 0,
+        epsilon: { horizontal: horizontalEpsilon, vertical: 0.001 },
+      };
+
+      runStack(margin, { items: [a, b] });
+      return { a, b };
+    }
+
+    it("with the default (tight) tolerance, a genuine small horizontal overlap is detected and the item is pushed to a new row", () => {
+      const { a, b } = horizontalOverlapScenario(0.001);
+
+      assert.equal(a.top, 0);
+      assert.equal(b.top, 20);
+    });
+
+    it("with a larger tolerance, the pair is excluded from the collision search window entirely, so the overlap is missed", () => {
+      const { a, b } = horizontalOverlapScenario(1);
+
+      assert.equal(a.top, 0);
+      assert.equal(
+        b.top,
+        0,
+        "b is left overlapping a on screen, the vertical check never even runs for this pair",
+      );
+    });
+  });
+});

--- a/test/TimelineItemSet.test.js
+++ b/test/TimelineItemSet.test.js
@@ -173,5 +173,41 @@ describe("Timeline ItemSet", () => {
         vertical: 0.001,
       });
     });
+
+    it("two separate partial updates each stick, without resetting the other axis", () => {
+      const body = getBasicBody();
+      const itemset = new ItemSet(body, {});
+      itemset.setOptions({ margin: { epsilon: { horizontal: 5 } } });
+      itemset.setOptions({ margin: { epsilon: { vertical: 9 } } });
+      assert.deepEqual(itemset.options.margin.epsilon, {
+        horizontal: 5,
+        vertical: 9,
+      });
+    });
+
+    it("a number shorthand on setOptions() overrides both axes, even if previously customized", () => {
+      const body = getBasicBody();
+      const itemset = new ItemSet(body, {
+        margin: { epsilon: { horizontal: 5, vertical: 9 } },
+      });
+      itemset.setOptions({ margin: { epsilon: 2 } });
+      assert.deepEqual(itemset.options.margin.epsilon, {
+        horizontal: 2,
+        vertical: 2,
+      });
+    });
+
+    it("a plain number margin (legacy shorthand for axis/item spacing) does not touch epsilon", () => {
+      const body = getBasicBody();
+      const itemset = new ItemSet(body, { margin: { epsilon: 3 } });
+      itemset.setOptions({ margin: 20 });
+      assert.equal(itemset.options.margin.axis, 20);
+      assert.equal(itemset.options.margin.item.horizontal, 20);
+      assert.equal(itemset.options.margin.item.vertical, 20);
+      assert.deepEqual(itemset.options.margin.epsilon, {
+        horizontal: 3,
+        vertical: 3,
+      });
+    });
   });
 });

--- a/test/TimelineItemSet.test.js
+++ b/test/TimelineItemSet.test.js
@@ -133,4 +133,45 @@ describe("Timeline ItemSet", () => {
     assert.equal(itemset.getItems().length, 2);
     assert.deepEqual(itemset.getItems(), internals.testitems);
   });
+
+  describe("margin.epsilon option", () => {
+    it("defaults to 0.001 for both horizontal and vertical", () => {
+      const body = getBasicBody();
+      const itemset = new ItemSet(body, {});
+      assert.deepEqual(itemset.options.margin.epsilon, {
+        horizontal: 0.001,
+        vertical: 0.001,
+      });
+    });
+
+    it("accepts a plain number, applying it to both axes", () => {
+      const body = getBasicBody();
+      const itemset = new ItemSet(body, { margin: { epsilon: 1 } });
+      assert.deepEqual(itemset.options.margin.epsilon, {
+        horizontal: 1,
+        vertical: 1,
+      });
+    });
+
+    it("accepts a partial object, leaving the other axis at its default", () => {
+      const body = getBasicBody();
+      const itemset = new ItemSet(body, {
+        margin: { epsilon: { vertical: 1 } },
+      });
+      assert.deepEqual(itemset.options.margin.epsilon, {
+        horizontal: 0.001,
+        vertical: 1,
+      });
+    });
+
+    it("can be updated via setOptions() after construction", () => {
+      const body = getBasicBody();
+      const itemset = new ItemSet(body, {});
+      itemset.setOptions({ margin: { epsilon: { horizontal: 2 } } });
+      assert.deepEqual(itemset.options.margin.epsilon, {
+        horizontal: 2,
+        vertical: 0.001,
+      });
+    });
+  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -219,9 +219,20 @@ export interface TimelineMarginItem {
 
 export type TimelineMarginItemType = number | TimelineMarginItem;
 
+export interface TimelineMarginEpsilon {
+  /** Tolerance used for horizontal (start/end, or left/right) collision checks. Defaults to 0.001. */
+  horizontal?: number;
+  /** Tolerance used for the vertical (top/height) collision check that decides whether items are pushed onto separate rows. Defaults to 0.001. */
+  vertical?: number;
+}
+
+export type TimelineMarginEpsilonType = number | TimelineMarginEpsilon;
+
 export interface TimelineMarginOption {
   axis?: number;
   item?: TimelineMarginItemType;
+  /** Tolerance used when checking collisions during stacking, to prevent round-off errors. Defaults to 0.001 for both horizontal and vertical. */
+  epsilon?: TimelineMarginEpsilonType;
 }
 
 export interface TimelineOrientationOption {


### PR DESCRIPTION
## Problem

`Stack.js` uses a single hardcoded `EPSILON` (`0.001`) as the tolerance for collision checks during stacking, to compensate for floating-point round-off in item positions (`left`/`width`/`height`/`top`), which ultimately come from DOM measurements and time-to-pixel conversions.

#1935 reported that this tolerance is too tight in practice: items that should be considered touching or overlapping end up on separate rows (or the computed row height overflows) because of sub-pixel differences. The proposed fix there was to raise `EPSILON` from `0.001` to `1`.

That fix works, but as [@Thomaash pointed out in review](https://github.com/visjs/vis-timeline/pull/1935#pullrequestreview-3274725868), raising a shared internal constant by three orders of magnitude with no supporting data changes the default layout behavior for every consumer of the library, with no way to opt out. It also conflates two different roles the same constant plays inside `performStacking`:

1. A **horizontal search-window optimization** (deciding which already-positioned items are worth comparing against) — not visually meaningful on its own.
2. The actual **vertical top/height collision test** (`checkVerticalSpatialCollision`) that decides whether two items get pushed onto separate rows.

Bumping both by the same amount can hide genuinely distinct items that overlap by more than a fraction of a pixel but less than the new tolerance.

## Fix

This PR turns `EPSILON` into a `margin.epsilon` timeline option instead of a hardcoded constant, split into `horizontal` and `vertical` tolerances (mirroring the existing `margin.item.{horizontal,vertical}` shape):

```js
new Timeline(container, items, groups, {
  margin: {
    epsilon: {
      horizontal: 0.001, // default, unchanged
      vertical: 1, // opt in to a larger tolerance for the vertical collision test
    },
  },
});
```

Both default to `0.001`, so this is fully backward compatible: nothing changes for existing users unless they explicitly opt in. Applications that hit the overlap/overflow issue from #1935 can pick the tolerance that fits their data, without changing the default for everyone else, and can tune the horizontal and vertical tolerances independently.

As with `margin.item`, `margin.epsilon` also accepts a plain number as shorthand for setting both `horizontal` and `vertical` to the same value.

## Changes

- `lib/timeline/Stack.js` — `EPSILON` constant replaced by `epsilon`/`verticalEpsilon` parameters threaded through `stack()`, `substack()`, `stackSubgroups()`, `performStacking()`, and `checkVerticalSpatialCollision()`.
- `lib/timeline/component/ItemSet.js` — default value (`{ horizontal: 0.001, vertical: 0.001 }`), option parsing (number-or-object, like `margin.item`), and propagation into the margin object passed down to `Group`/`Stack`.
- `lib/timeline/optionsTimeline.js` — option validation and configuration panel entry.
- `types/index.d.ts` — `TimelineMarginOption.epsilon`.
- `docs/timeline/index.html` — option documentation.

## Relation to #1935

This is an alternative to #1935 that keeps its motivation but makes the tolerance configurable per application instead of a single hardcoded default. I'll leave a comment on #1935 pointing here.
